### PR TITLE
State can outlive the process

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -43,6 +43,6 @@ body:
     attributes:
       label: Version
       description: The StateUI version, and the .NET and Swift toolchains if the build is what failed.
-      placeholder: StateUI 0.1.0, .NET 10.0.100, Swift 6.3.3
+      placeholder: StateUI 0.1.1, .NET 10.0.100, Swift 6.3.3
     validations:
       required: true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,9 +23,11 @@
 #      signed and even an allowlisted committer is reported. Measured on the
 #      first pull request this repository had.
 #
-# The action is pinned to a released version. To harden it further, replace the
-# tag with its commit SHA, which cannot be moved:
-#   contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
+# The action is pinned to a COMMIT SHA, which cannot be moved, with the release
+# it belongs to in the comment beside it - v2.6.1, and the newest there is;
+# upstream has published nothing since September 2024. That is also why the run
+# warns about Node 20: the action declares it, the runner forces Node 24, and
+# the fix is upstream's to ship.
 
 name: CLA
 
@@ -49,7 +51,7 @@ jobs:
         # The comment condition is what lets a contributor sign by replying, and
         # `recheck` is how a maintainer re-runs it without a new commit.
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
@@ -59,3 +61,12 @@ jobs:
           branch: cla-signatures
           # The owner's own commits need no signature, and neither do bots.
           allowlist: idexus,dependabot[bot],github-actions[bot]
+          # THE CONVERSATION STAYS OPEN. The default locks a pull request once
+          # the CLA is satisfied, so that a contributor cannot delete the
+          # comment they signed in - but the RECORD is the commit in
+          # signatures/v1/cla.json, which no comment can touch, and locking
+          # stops only NEW comments while leaving an old one editable. What it
+          # costs is real: a contributor signs on their first comment, and
+          # review starts right after, so the lock takes their voice away
+          # exactly when they need it.
+          lock-pullrequest-aftermerge: false

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,7 +10,18 @@
 #      with Contents: read and write on this repository. GITHUB_TOKEN cannot be
 #      used for it - a token issued to a workflow run cannot push to a branch
 #      the run did not check out.
-#   2. Nothing else. The branch is created on the first signature.
+#   2. The `cla-signatures` branch itself, which THIS ACTION DOES NOT CREATE.
+#      An empty orphan branch is all it wants:
+#
+#          git switch --orphan cla-signatures
+#          git commit --allow-empty -m "CLA signatures"
+#          git push -u origin cla-signatures
+#
+#      Without it every run fails with "Branch cla-signatures not found", and
+#      the message BEFORE it says the committers have to sign - which is the
+#      consequence, not the cause: with no signature file to read, nobody is
+#      signed and even an allowlisted committer is reported. Measured on the
+#      first pull request this repository had.
 #
 # The action is pinned to a released version. To harden it further, replace the
 # tag with its commit SHA, which cannot be moved:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,14 @@
   //                                     compound at the bottom for why)
   //   Device or Android, Swift       -> not supported (see below)
   //
+  // THE PICKER LISTS THEM IN THAT ORDER, and the order is the table's reason:
+  // widest first. "Debug app (C#)" runs on every platform and every device, so
+  // it is what F5 offers before anything is chosen; the Mac Catalyst compound
+  // is the narrowest and sits below the two Swift-capable ones. What decides
+  // that is `presentation.order` on each entry, NOT the order they appear in
+  // this file - a compound is sorted in among the configurations by the same
+  // number.
+  //
   // "Debug app (C#)" follows BOTH pickers: ".NET MAUI: Select Startup Project"
   // says which app, the status bar says which simulator, emulator or device -
   // and the Swift library is compiled for that platform, from that project's
@@ -62,7 +70,7 @@
       "name": "Debug app (C#)",
       "type": "maui",
       "request": "launch",
-      "presentation": { "group": "1 app", "order": 2 }
+      "presentation": { "group": "1 app", "order": 1 }
     },
     {
       // The same launch against the RELEASE build. Both pickers still apply -
@@ -85,7 +93,7 @@
       "type": "maui",
       "request": "launch",
       "configuration": "Release",
-      "presentation": { "group": "1 app", "order": 3 }
+      "presentation": { "group": "1 app", "order": 2 }
     },
     {
       // Swift side, attaching to an app the C# session started.
@@ -155,7 +163,7 @@
           "process attach --name Gallery.exe"
         ]
       },
-      "presentation": { "group": "1 app", "order": 4 }
+      "presentation": { "group": "1 app", "order": 3 }
     },
 
     {
@@ -271,7 +279,7 @@
         "Attach Swift debugger"
       ],
       "stopAll": true,
-      "presentation": { "group": "1 app", "order": 1 }
+      "presentation": { "group": "1 app", "order": 4 }
     }
   ]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ import PackageDescription
 // package's manifest from the root of the checkout and nowhere else, so this is
 // the one place it can sit if anybody is to write
 //
-//     .package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.0")
+//     .package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.1")
 //
 // The code stays under src/StateUI/ regardless, which is what the paths below
 // say - Swift and C# still never share a directory.

--- a/README.md
+++ b/README.md
@@ -242,8 +242,7 @@ its view type, the same rule that keeps a control between renders. A child that
 needs the value borrows it with `@Binding` - `$counter` lends it - and writes
 through the binding reach the owner. Leaving the tree is what ends a view's
 state; state that should live as long as the app goes on the `Application`,
-which is built once and kept. The same split SwiftUI makes, for the same
-reason.
+which is built once and kept.
 
 Swift allows no property wrapper on a file-scope variable at all ("property
 wrappers are not yet supported in top-level code"), so state belonging to no
@@ -385,11 +384,9 @@ struct ChildView: ContentView {
 }
 ```
 
-The name and the semantics are SwiftUI's modern by-type environment, the same
-way `@State` and `@Binding` are SwiftUI's - the view layer speaks MAUI, the
-state layer speaks SwiftUI. One way each: `.environment()` is the only way to
-provide, `@Environment` the only way to consume, and a nearer `.environment()`
-of the same type overrides for its own branch.
+One way each: `.environment()` is the only way to provide, `@Environment` the
+only way to consume, and a nearer `.environment()` of the same type overrides
+for its own branch.
 
 The rebuild rules are the ordinary ones, and they land exactly where wanted:
 the provider passes a reference and reads no property, so a write IN the
@@ -1612,9 +1609,9 @@ representable in C, while `Label` and `Button` are managed objects living in the
    owns event handlers          │   ← event id │  forwards events back
 ```
 
-Swift **describes**, C# **materializes**. It is the same split React Native and
-Flutter use, and it is what makes a declarative Swift API possible over a UI
-framework that knows nothing about Swift.
+Swift **describes**, C# **materializes**. That split is what makes a
+declarative Swift API possible over a UI framework that knows nothing about
+Swift.
 
 A render cycle:
 
@@ -2150,8 +2147,7 @@ scroll offset and running animations across a render: they live in the control,
 not in the tree.
 
 Identities come from the renderer unless the author supplies one - and a
-loop's rows are identified by their ITEMS, which is `ForEach`, SwiftUI's rule
-and spelling:
+loop's rows are identified by their ITEMS, which is what `ForEach` is for:
 
 ```swift
 VStack {
@@ -2288,12 +2284,12 @@ tapping a counter on another page:
 | rows reordered | 4 | 4 |
 | one row removed | 3 | 4 |
 
-The promise it asks for is "everything this view shows comes from these inputs" -
-the same one React's `memo` and SwiftUI's `EquatableView` ask for, and broken the
-same way: *copying* state into the view during a render and expecting the copy
-to keep up. Reading state is fine twice over - a handler reads the reference
-when it fires, and a body's reads are recorded, so a `@State` that changes
-under an unchanged token is found and rebuilt by the walk below.
+The promise it asks for is "everything this view shows comes from these
+inputs", and there is one way to break it: *copying* state into the view during
+a render and expecting the copy to keep up. Reading state is fine twice over -
+a handler reads the reference when it fires, and a body's reads are recorded,
+so a `@State` that changes under an unchanged token is found and rebuilt by the
+walk below.
 
 `.id()` belongs on the memoized wrapper rather than on the view inside it:
 identity is decided before anything is built, and the view inside may not be
@@ -2386,8 +2382,7 @@ VStack { … }
 ```
 
 `FrameReader` builds on it, for content that cannot be described until its
-space is known - SwiftUI's GeometryReader, the content closure handed the
-measured `Rect`:
+space is known - the content closure is handed the measured `Rect`:
 
 ```swift
 FrameReader { frame in
@@ -2670,67 +2665,34 @@ The group names follow the WinUI Gallery's, because those are the ones people
 already look under. What goes in each is MAUI's business: a `Picker` is basic
 input here because MAUI treats it as one.
 
-### What it looks like
+### Replacing the artwork
 
-Swift's orange meeting .NET's violet, which is what the library is. Two
-decisions carry it, and both are in `Resources/`:
+The gallery's own look is in `Styles/` and `Resources/`, and an app made from
+the template carries four SVGs of the same shape to paint over. Three things
+about doing that belong to the platforms rather than to this project, and each
+of them fails quietly:
 
-- **The neutrals are tinted violet, not grey.** A `#808080` is what an interface
-  has when nobody chose; a neutral carrying a trace of the brand hue reads as one
-  designed thing. It is a few points of blue in every step of the ramp.
-- **The accent is Swift's orange, against a violet ground.** Near-complementary,
-  so anything chosen - a switch that is on, the chevron on a card, the row you
-  are on - separates from the page without also being bigger or bolder.
+- **Renaming the file a `MauiIcon` includes renames what MAUI generates from
+  it**, and three files name that by hand: `android:icon="@mipmap/<name>"` in
+  AndroidManifest.xml, and `Assets.xcassets/<name>.appiconset` in the iOS and
+  the Mac Catalyst `Info.plist`. Miss one and the icon is silently absent
+  rather than wrong.
+- **Android shows only the middle of an icon.** An adaptive icon is a 108dp
+  canvas of which a launcher crops 72dp, so identical artwork reads half again
+  too big there - the real cause of "bigger on one device, smaller on another".
+  `ForegroundScale="0.667"` on a `MauiIcon Update` conditioned on Android puts
+  it back.
+- **A launch screen has no dark variant to give.** Resizetizer honours one
+  `Color` on a `MauiSplashScreen` and there is no `DarkColor`. Android has the
+  mechanism - `Platforms/Android/Resources/values-night/maui_colors.xml` names
+  the same resource MAUI generated, and the platform prefers it while the system
+  is dark - while iOS shows the light one either way, its launch screen being a
+  generated storyboard with the value written into it. Artwork that reads in
+  both themes is what makes one file serve both.
 
-The interactive orange is *deeper* than Swift's own in the light theme and
-*lighter* in the dark: white on `#F05138` is 3.5:1, which fails WCAG AA for text,
-and `#CE3F1C` is 4.8:1. The brand orange stays exactly Swift's wherever nothing
-has to be read on top of it.
-
-Three layers, and each may only reach for the one under it: `AppColors` says what
-a colour **is**, `Palette` says what it is **for** - `accent`, `subtle`,
-`surface`, `raised`, `selected` - and `AppStyles` says what a **control**
-looks like. A view naming a raw colour is the thing that makes a palette drift,
-so almost none of them do.
-
-The mark is two identical plates, offset, sharing an opening: two runtimes, one
-surface. The opening is their intersection, removed with `fill-rule="evenodd"`,
-so whatever is behind shows through the middle - which is why the file is one
-colour and gets drawn in white on the identity gradient. It is deliberately
-neither Swift's bird nor MAUI's ribbon; what it takes from both is the palette it
-sits on.
-
-The same path is drawn in four places, and changing one means changing all
-four: `Resources/Images/stateui_mark.svg` for the app, `Resources/AppIcon/
-stateui_mark.svg` for the icon (over `stateui_bkg.svg`, its gradient ground),
-`Resources/Splash/splash.svg` for the launch screen, and
-`Resources/Images/stateui_tile.svg` for the mark and its ground as one image -
-which a scaffolded app and the `dotnet new` template carry, on their one page,
-rather than the gallery.
-
-**The mark fills 54.17% of its box in every one of them.** Four different
-fractions are exactly what makes it look a different size in every place it
-appears - and a bare mark carries the same margin the tile fills with gradient,
-so asking for 84 points draws the same mark either way. Android is the one
-platform a file cannot answer alone: an adaptive icon is a 108dp
-canvas of which a launcher shows 72dp, so the same artwork reads half again too
-big there. `ForegroundScale="0.667"` on a `MauiIcon Update` conditioned on
-Android puts it back - measured on the generated foreground, the mark covers
-36.6% of the canvas and so 54.9% of what the crop leaves.
-
-Renaming the file the `MauiIcon` includes renames what MAUI generates from it,
-and three files name that by hand: `android:icon="@mipmap/<name>"` in
-AndroidManifest.xml, and `Assets.xcassets/<name>.appiconset` in the iOS and Mac
-Catalyst `Info.plist`. The launch screen is the white mark on .NET's violet - the colour the
-icon is and the colour the navigation bar is - so the app opens *into* what it
-launched from rather than flashing white first. MAUI's Resizetizer honours one
-`Color` and has no dark variant, so the dark theme is done where a platform has
-a way to: Android reads
-`Platforms/Android/Resources/values-night/maui_colors.xml`, which names the same
-resource MAUI generated and wins while the system is dark. iOS shows the light
-one in both, its launch screen being a generated storyboard with the colour
-written into it. The mark is white either way, which is what lets one piece of
-artwork serve both.
+And one that is nobody's platform: **keep the mark the same fraction of its box
+in every file it appears in.** Four files drawn to four different proportions is
+what makes an icon look a different size in every place it shows up.
 
 ### Adding a sample
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,34 @@ comment about.
 In VS Code, two extensions: **.NET MAUI** (Microsoft), which gives the device
 picker and F5, and **Swift** (swiftlang), which gives completion and LLDB.
 
-The first build of a new app downloads the Swift package and compiles a macro
-plugin - swift-syntax, several minutes, once per `.build` directory. Everything
-after that is incremental, per file.
+### The first build takes minutes, and then it takes seconds
+
+**A cold build can run ten minutes or more, and nothing in the output says
+why.** It is not a hang, and it is paid once. What it is doing is compiling
+**swift-syntax**, which is the only third-party dependency this project has.
+
+It is there for `@StateClass`. Giving a class's stored properties accessors is
+something no library can do from the outside, so that one feature is a Swift
+MACRO - and a macro is an executable the COMPILER runs while it compiles your
+code. SwiftPM therefore builds swift-syntax from source, on the machine doing
+the build, before anything of yours is compiled. **Nothing of it is linked into the
+app or reaches a device**; it is a build-time tool, like a code generator.
+
+Measured: about five minutes on an Apple laptop, ten or more on Windows. It
+happens **once per `.build` directory**, always in release, whatever
+configuration you are building - so an app made by `dotnet new stateui` pays it
+once, and a clone of this repository has four of them (the library package, the
+tests, and each app under `apps/`), each paid the first time something needs it.
+
+After that the build finds the plugin and skips straight past it, and everything
+else is incremental per file - one changed file in the library is **10.5s** on
+Mac Catalyst, and a build with nothing changed is **5.4s**. See
+[Incremental builds](#incremental-builds) for the whole table.
+
+The one thing that makes you pay it again is deleting `.build`, which the VS
+Code task **"Clean app (everything)"** deliberately does - it is the only clean
+that makes an edited `Info.plist` take effect, and the swift-syntax build is its
+price.
 
 ## The API is MAUI's
 
@@ -3903,6 +3928,11 @@ dotnet build -c Debug -f net10.0-maccatalyst -r maccatalyst-arm64
 The Swift library is compiled automatically as part of the build - the right
 variant for the target, in the right debug format for the platform's debugger.
 It is incremental: the native build only reruns when a `.swift` file changes.
+
+**The first build in a fresh clone is the slow one** - ten minutes or more,
+compiling swift-syntax for the macro plugin. It is paid once per `.build`
+directory; see [The first build takes minutes, and then it takes
+seconds](#the-first-build-takes-minutes-and-then-it-takes-seconds).
 
 | What | How |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -4503,7 +4503,7 @@ The repository IS the package: `Package.swift` at the root, the code under
 tagging a version; a consumer writes
 
 ```swift
-.package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.0")
+.package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.1")
 ```
 
 The manifest is at the root because SwiftPM reads one from nowhere else - which

--- a/README.md
+++ b/README.md
@@ -253,6 +253,74 @@ private let counter = State(0)
 counter.update { $0 + 1 }
 ```
 
+### State that outlives the process
+
+`@State` under a **key** is kept: the value the reader left behind is there
+again on the next launch, and nothing about reading or writing it changes.
+
+```swift
+extension PersistentKey {
+    static let lastGroup = PersistentKey("com.example.lastGroup", of: Int.self)
+    static let appearance = PersistentKey("com.example.appearance", of: Appearance.self)
+}
+
+struct GroupPage: ContentPage {
+    @State(.lastGroup) private var group = 0
+}
+```
+
+The value written beside the state - `= 0` - is what it holds when the store has
+nothing under that name, so the default stays where it can be seen. There is
+nothing to await on either side: the whole store is read into memory at startup,
+before the first view is built, and a write reaches it by itself. A key written
+several times between two renders is saved once, holding the last value, so an
+`Entry` bound to kept state saves when the typing stops rather than once per
+letter.
+
+**The application lists its keys**, and that is what makes the read possible at
+all: a settings store is read one key at a time and offers no list of what it
+holds, so naming them is the only way the host can have the values before
+anything asks for one.
+
+```swift
+// On the Application:
+var persistentKeys: [PersistentKey] { [.lastGroup, .appearance] }
+```
+
+A key holds what a platform's settings store holds - a whole number, a number,
+true or false, or text - and an enum over one of those is one line:
+
+```swift
+enum Appearance: String, PersistentValue { case light, dark, system }
+```
+
+The kind comes from the Swift type named at the key, so `of: Int.self` and
+`var group = 0` are the same word twice, and a mismatch between them stops the
+app the first time that view is built, naming the key. Anything larger than those four belongs in a
+model the application saves itself.
+
+**One key is one piece of state, everywhere in the application.** Two views
+declaring the same key share the storage rather than a copy of the value, so a
+write in either rebuilds the readers in both.
+
+Where it is kept is MAUI's `Preferences` - `NSUserDefaults`,
+`SharedPreferences`, `ApplicationDataContainer` - so these sit beside whatever
+else the app keeps in the platform's own settings. An application that wants its
+own store names one the host registered:
+
+```swift
+var persistentStorage: PersistentStorage { PersistentStorage("MyApp.Json") }
+```
+
+```csharp
+// C#, in MauiProgram.CreateMauiApp:
+StateUIStores.Add("MyApp.Json", new JsonPreferences(path));
+```
+
+A store is an `IPreferences`, MAUI's own interface - the one
+`Preferences.Default` implements - so a store written against MAUI works here
+unchanged.
+
 ### State in a class
 
 `@State` answers one question - a view is a value, rebuilt every render, so where
@@ -4558,9 +4626,11 @@ fast test rather than a slow build.
 Where this would go next, in order of value - the top three being what a
 production application reaches for first:
 
-- **Keeping a value across launches.** `Preferences` and `SecureStorage` as
-  acts: the no-Foundation rule means there is no `UserDefaults` on this side,
-  so today an application cannot keep a setting or a token at all.
+- **A secure place for a token.** `SecureStorage` as acts - the keychain on
+  Apple, the keystore on Android, DPAPI on Windows. Kept state covers a setting;
+  a credential wants a store that encrypts it, and MAUI's is asynchronous, which
+  suits an act awaited from a handler rather than the synchronous read a
+  `@State` is.
 - **Reaching out of the application.** `Launcher`/`Browser.OpenAsync` for a
   link, a `mailto:` or a `tel:`; `Clipboard`; `Share.RequestAsync` - each one
   act and one case, the pattern `Dialogs` just followed.

--- a/apps/Gallery/Package.swift
+++ b/apps/Gallery/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         // manifest lives. An app outside this repository writes the published
         // package instead, and changes nothing else:
         //
-        //     .package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.0")
+        //     .package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.1")
         .package(path: "../.."),
     ],
     targets: [

--- a/apps/Gallery/Swift/Gallery/Catalog.swift
+++ b/apps/Gallery/Swift/Gallery/Catalog.swift
@@ -52,6 +52,7 @@ struct Catalog {
                 icon: ImageSource(light: "nav_state.png", dark: "nav_state_dark.png"),
                 samples: [
                     Sample(StateSample()),
+                    Sample(PersistentStateSample()),
                     Sample(StateClassSample()),
                     Sample(ControlStateSample()),
                     Sample(WatchedFlightSample()),

--- a/apps/Gallery/Swift/Gallery/MenuTitle.swift
+++ b/apps/Gallery/Swift/Gallery/MenuTitle.swift
@@ -27,6 +27,6 @@ struct MenuTitle: ContentView {
             .fontSize(17)
             .fontAttributes(.bold)
             .textColor(Palette.onBrand)
-            .verticalOptions(.center)        
+            .verticalOptions(.center)
     }
 }

--- a/apps/Gallery/Swift/GalleryApp.swift
+++ b/apps/Gallery/Swift/GalleryApp.swift
@@ -202,6 +202,16 @@ struct GalleryApp: Application {
     /// it: the SearchBar's touch floor is the phone's, not the desktop's.
     /// See Styles/AppStyles.swift.
     var styles: StyleSheet? { AppStyles.sheet(on: device.idiom) }
+
+    /// What the gallery KEEPS between launches - `PersistentStateSample`'s
+    /// three settings, and nothing else.
+    ///
+    /// Listed because a settings store is read one key at a time and offers no
+    /// list of what it holds, so this is the only way the host can have the
+    /// values in memory before the first view asks for one. Kept in the
+    /// platform's own store, which is what an application that leaves
+    /// `persistentStorage` alone says.
+    var persistentKeys: [PersistentKey] { [.visits, .who, .shade] }
 }
 
 /// The one thing this module exports.

--- a/apps/Gallery/Swift/Samples/State/PersistentStateSample.swift
+++ b/apps/Gallery/Swift/Samples/State/PersistentStateSample.swift
@@ -1,0 +1,147 @@
+import StateUI
+
+/// How dark the gallery's own demonstration paints - kept as the text it is
+/// spelled with, which is what makes conformance one line.
+enum Shade: String, PersistentValue {
+    case quiet
+    case bold
+}
+
+extension PersistentKey {
+    /// How many times the reader has pressed the button, ever.
+    static let visits = PersistentKey("dev.stateui.gallery.visits", of: Int.self)
+
+    /// What the reader is called.
+    static let who = PersistentKey("dev.stateui.gallery.who", of: String.self)
+
+    /// Whether the panel below paints loudly.
+    static let shade = PersistentKey("dev.stateui.gallery.shade", of: Shade.self)
+}
+
+/// `@State` under a key is state the application KEEPS - the value is there
+/// again the next time the app opens, with nothing to load and nothing to save.
+struct PersistentStateSample: SampleContent {
+    @State(.visits) private var visits = 0
+    @State(.who) private var who = ""
+    @State(.shade) private var shade = Shade.quiet
+
+    static let id = "persistent-state"
+    static let title = "Kept state"
+    static let summary = "State under a key survives the app being closed."
+
+    static let code = """
+        extension PersistentKey {
+            static let visits = PersistentKey("dev.stateui.gallery.visits", of: Int.self)
+            static let who = PersistentKey("dev.stateui.gallery.who", of: String.self)
+        }
+
+        // On the Application, so the host knows what to read before the
+        // first view is built:
+        var persistentKeys: [PersistentKey] { [.visits, .who] }
+
+        // And then it is ordinary state:
+        @State(.visits) private var visits = 0
+        @State(.who) private var who = ""
+
+        VStack {
+            Label("Pressed \\(visits) times, ever")
+
+            Button("Press")
+                .onClicked { visits += 1 }
+
+            Entry($who)
+                .placeholder("Your name")
+        }
+        """
+
+    var notes: Element? {
+        VStack {
+            Label("Close the app completely and open it again: the count and the name "
+                + "are where you left them.")
+                .fontSize(12)
+                .textColor(Palette.subtle)
+
+            Label("The value written beside the state - `= 0` - is what it holds when "
+                + "the store has nothing under that name, so the default stays where "
+                + "it can be seen. Reading and writing are exactly what they are on any "
+                + "other @State: nothing is awaited, and a write reaches the store by "
+                + "itself.")
+                .fontSize(12)
+                .textColor(Palette.subtle)
+
+            Label("The application LISTS its keys, in persistentKeys. That is not "
+                + "ceremony: a settings store is read one key at a time and offers no "
+                + "list of what it holds, so naming them is the only way the host can "
+                + "have the values in memory before the first view asks for one.")
+                .fontSize(12)
+                .textColor(Palette.subtle)
+
+            Label("They are kept in the platform's own settings store - NSUserDefaults, "
+                + "SharedPreferences, ApplicationDataContainer - beside whatever else "
+                + "the app keeps there. So a key can hold only what such a store holds: "
+                + "a whole number, a number, true or false, or text. An enum over one of "
+                + "those is one line, as Shade is here.")
+                .fontSize(12)
+                .textColor(Palette.subtle)
+        }
+        .spacing(12)
+    }
+
+    var content: Element {
+        VStack {
+            Label("Pressed \(visits) times, ever")
+                .fontSize(22)
+                .horizontalTextAlignment(.center)
+
+            HStack {
+                Button("Press")
+                    .backgroundColor(Palette.accent)
+                    .cornerRadius(8)
+                    .padding(20, 10)
+                    .onClicked { visits += 1 }
+
+                Button("Start over")
+                    .borderColor(Palette.outline)
+                    .borderWidth(1)
+                    .backgroundColor(.transparent)
+                    .textColor(Palette.subtle)
+                    .cornerRadius(8)
+                    .padding(20, 10)
+                    .isEnabled(visits != 0)
+                    .onClicked { visits = 0 }
+            }
+            .spacing(12)
+            .horizontalOptions(.center)
+
+            Entry($who)
+                .placeholder("Your name")
+
+            Label(who.isEmpty ? "Welcome back" : "Welcome back, \(who)")
+                .fontSize(17)
+                .horizontalTextAlignment(.center)
+
+            // A key whose value is an enum - kept as the word it is spelled
+            // with, so anything else that opens the store can read it.
+            HStack {
+                Label("Shade")
+                    .verticalOptions(.center)
+
+                Button(shade == .quiet ? "quiet" : "bold")
+                    .borderColor(Palette.outline)
+                    .borderWidth(1)
+                    .backgroundColor(.transparent)
+                    .textColor(Palette.subtle)
+                    .cornerRadius(8)
+                    .padding(16, 8)
+                    .onClicked { shade = shade == .quiet ? .bold : .quiet }
+            }
+            .spacing(12)
+
+            BoxView()
+                .heightRequest(48)
+                .color(shade == .bold ? Palette.accent : Palette.surface)
+                .cornerRadius(8)
+        }
+        .spacing(14)
+    }
+}

--- a/apps/HelloWorld/Package.swift
+++ b/apps/HelloWorld/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         // manifest lives. An app outside this repository writes the published
         // package instead, and changes nothing else:
         //
-        //     .package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.0")
+        //     .package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.1")
         .package(path: "../.."),
     ],
     targets: [

--- a/src/StateUI.Runtime/Interop/NativeMethods.cs
+++ b/src/StateUI.Runtime/Interop/NativeMethods.cs
@@ -262,6 +262,34 @@ internal static partial class NativeMethods
     internal static partial int SetEnvironment(byte[] bytes, int length);
 
     /// <summary>
+    /// Asks which store the application keeps state in and every key it keeps
+    /// there. Writes the byte count into <paramref name="length"/> and returns
+    /// <see cref="IntPtr.Zero"/> for an application that keeps nothing.
+    /// </summary>
+    /// <remarks>
+    /// Called once, after the app registers and before the first render: a
+    /// settings store is read key by key and never enumerated, so this is the
+    /// only way the host can learn what to ask it for - and the state has to
+    /// hold the kept value before the first view reads it. The caller owns the
+    /// memory and must release it with <see cref="FreeBuffer"/>.
+    /// </remarks>
+    /// <param name="length">The announcement's byte count.</param>
+    [LibraryImport(Lib, EntryPoint = "stateui_persistent_keys")]
+    internal static partial IntPtr PersistentKeys(out int length);
+
+    /// <summary>
+    /// Tells Swift what the store held - a name and a value per key that was
+    /// there, written with <see cref="SwiftWire.WritePersistent"/>.
+    /// </summary>
+    /// <remarks>
+    /// Returns 1 applied, -1 for a buffer that would not read, which is
+    /// reported once as version skew. The buffer is read before the call
+    /// returns, so nothing is pinned past it and nothing is freed.
+    /// </remarks>
+    [LibraryImport(Lib, EntryPoint = "stateui_set_persistent")]
+    internal static partial int SetPersistent(byte[] bytes, int length);
+
+    /// <summary>
     /// Copies a string returned by Swift and releases the native allocation.
     /// </summary>
     /// <remarks>

--- a/src/StateUI.Runtime/Protocol/SwiftAct.cs
+++ b/src/StateUI.Runtime/Protocol/SwiftAct.cs
@@ -74,4 +74,8 @@ public enum SwiftAct : ushort
     /// <summary>StateUI.StopFlight - this library's own, animation having
     /// stopped being a method to call.</summary>
     StopFlight = 33,
+
+    /// <summary>StateUI.PersistValue - this library's own: one kept key's new
+    /// value, on its way to the store.</summary>
+    PersistValue = 34,
 }

--- a/src/StateUI.Runtime/Protocol/SwiftCommand.cs
+++ b/src/StateUI.Runtime/Protocol/SwiftCommand.cs
@@ -73,6 +73,19 @@ public sealed class SwiftCommand
     public string? GetString(int index) =>
         At(index) is { Tag: SwiftWireValue.TagString } value ? value.Text : null;
 
+    /// <summary>
+    /// An argument as a NAME from an open vocabulary - a style key, a kept
+    /// state's key - or null when there is none or it is something else.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <see cref="GetString"/>: a name and a piece of text
+    /// are different things on this wire and travel differently - a name rides
+    /// the session's dictionary and costs two bytes after the first use - so
+    /// nothing can take a label's words for a key somebody named.
+    /// </remarks>
+    public string? GetName(int index) =>
+        At(index) is { Tag: SwiftWireValue.TagName } value ? value.Text : null;
+
     /// <summary>An argument as a whole number, or null when there is none.</summary>
     public int? GetInt(int index) => GetDouble(index) is double value ? (int)value : null;
 

--- a/src/StateUI.Runtime/Protocol/SwiftPersistentKey.cs
+++ b/src/StateUI.Runtime/Protocol/SwiftPersistentKey.cs
@@ -1,0 +1,17 @@
+namespace StateUI.Runtime.Protocol;
+
+/// <summary>
+/// One piece of state the application keeps between launches: the name it is
+/// kept under, and what kind of value it is.
+/// </summary>
+/// <remarks>
+/// Announced by Swift before the first render - see
+/// <see cref="SwiftWire.ReadPersistentKeys"/> - because a settings store is
+/// read key by key and never enumerated, so the host cannot find out what to
+/// ask for by looking. The kind comes with it for the same reason: a store is
+/// typed, and reading an entry with the wrong overload is an error rather than
+/// a conversion.
+/// </remarks>
+/// <param name="Name">The name in the store, the application's own.</param>
+/// <param name="Kind">Which of the four kinds of value it holds.</param>
+internal readonly record struct SwiftPersistentKey(string Name, SwiftPersistentKind Kind);

--- a/src/StateUI.Runtime/Protocol/SwiftWire.cs
+++ b/src/StateUI.Runtime/Protocol/SwiftWire.cs
@@ -254,6 +254,79 @@ internal static partial class SwiftWire
             ?? throw new InvalidDataException($"the message uses name #{id}, never announced");
     }
 
+    /// <summary>
+    /// Reads the persistent-key announcement: which store the application
+    /// keeps state in, and every key it keeps there.
+    /// </summary>
+    /// <remarks>
+    /// <code>
+    /// [version: U8][storage: string][count: U16]
+    /// per key: [name: string][kind: U8]
+    /// </code>
+    /// <para>
+    /// Names in full rather than dictionary numbers: this is the first thing
+    /// either side says, before any message has announced anything, and the
+    /// names belong to the platform's store rather than to a session.
+    /// </para>
+    /// </remarks>
+    /// <param name="bytes">The buffer Swift answered with.</param>
+    /// <returns>The store's name and the keys, in the order declared.</returns>
+    internal static (string Storage, List<SwiftPersistentKey> Keys) ReadPersistentKeys(
+        ReadOnlySpan<byte> bytes)
+    {
+        var reader = new Reader(bytes);
+
+        byte version = reader.U8();
+        if (version != Version)
+        {
+            throw new InvalidDataException(
+                $"the keys say wire version {version} and this runtime reads {Version}");
+        }
+
+        string storage = reader.Str();
+        int count = reader.U16();
+        var keys = new List<SwiftPersistentKey>(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            string name = reader.Str();
+            keys.Add(new SwiftPersistentKey(name, (SwiftPersistentKind)reader.U8()));
+        }
+
+        return (storage, keys);
+    }
+
+    /// <summary>
+    /// Serializes what the store held, for Swift to hydrate its kept state
+    /// with - a name and a value per key that was THERE.
+    /// </summary>
+    /// <remarks>
+    /// <code>
+    /// [version: U8][count: U16]
+    /// per entry: [name: string][value]
+    /// </code>
+    /// <para>
+    /// A key the store had nothing under is simply left out, which is what
+    /// leaves the Swift state holding the value written beside it. No sentinel
+    /// stands in for absence here, the wire's rule.
+    /// </para>
+    /// </remarks>
+    /// <param name="found">Name and value, for the keys the store had.</param>
+    internal static byte[] WritePersistent(
+        IReadOnlyList<(string Name, SwiftWireValue Value)> found)
+    {
+        var bytes = new List<byte>(32) { Version };
+        Write(bytes, (ushort)found.Count);
+
+        foreach ((string name, SwiftWireValue value) in found)
+        {
+            Write(bytes, name);
+            Write(bytes, value);
+        }
+
+        return [.. bytes];
+    }
+
     /// <summary>Reads a whole batch of acts, announcements first.</summary>
     internal static List<SwiftCommand> ReadCommands(ReadOnlySpan<byte> bytes, SwiftWireDictionary names)
     {

--- a/src/StateUI.Runtime/Protocol/SwiftWireEnums.cs
+++ b/src/StateUI.Runtime/Protocol/SwiftWireEnums.cs
@@ -610,3 +610,12 @@ internal enum SwiftWindowPhase
     Deactivated = 1,
     Stopped = 2,
 }
+
+/// <summary>What kind of value a kept key holds. Swift: PersistentKind.</summary>
+internal enum SwiftPersistentKind
+{
+    Boolean = 0,
+    Integer = 1,
+    Number = 2,
+    Text = 3,
+}

--- a/src/StateUI.Runtime/Rendering/StateUIPersistence.cs
+++ b/src/StateUI.Runtime/Rendering/StateUIPersistence.cs
@@ -1,0 +1,307 @@
+using Microsoft.Maui.Storage;
+using StateUI.Runtime.Interop;
+using StateUI.Runtime.Protocol;
+
+namespace StateUI.Runtime.Rendering;
+
+/// <summary>
+/// KEPT STATE's host half: reads the application's settings out of a store
+/// before the first view is built, and writes each one back as it changes.
+/// See <c>Core/Persistence.swift</c> for the other half.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reading a Swift <c>@State</c> is synchronous, so a kept value has to be in
+/// memory before anything looks at it - a value fetched at read time would
+/// arrive a render late and the reader would watch the default flash past. The
+/// whole store is therefore hydrated inside one window at startup, after the
+/// app registers and before the first render, which is the only moment where
+/// the application exists and no view does.
+/// </para>
+/// <para>
+/// The application NAMES its keys because a settings store cannot be
+/// enumerated: <see cref="IPreferences"/> - and every platform store behind it,
+/// <c>NSUserDefaults</c>, <c>SharedPreferences</c>,
+/// <c>ApplicationDataContainer</c> - reads one key at a time and offers no list
+/// of what it holds. So the host asks Swift what to ask the store for.
+/// </para>
+/// <para>
+/// Saving goes the other way as an ordinary act, one per key per drain: the
+/// Swift side coalesces a burst of writes into the last value, so an
+/// <c>Entry</c> bound to kept state saves once when the typing stops rather
+/// than once per letter.
+/// </para>
+/// </remarks>
+internal static class StateUIPersistence
+{
+    /// <summary>What the application keeps, by name - filled at startup, and
+    /// what tells a save which overload to write with. A store is typed, and
+    /// the value on the wire cannot say whether a number was declared whole.</summary>
+    private static readonly Dictionary<string, SwiftPersistentKind> Kinds = [];
+
+    /// <summary>The same keys in the order the application declared them, so
+    /// what is read back reads in that order too.</summary>
+    private static List<SwiftPersistentKey> _keys = [];
+
+    /// <summary>Where it is kept, resolved once from the name Swift
+    /// announced.</summary>
+    private static IPreferences? _store;
+
+    /// <summary>Whether the store already refused something - a standing
+    /// condition, said once, the <see cref="StateUISession.Report"/> rule.</summary>
+    private static bool _said;
+
+    /// <summary>
+    /// Asks Swift what the application keeps and where, reads exactly those
+    /// keys, and hands back what was there.
+    /// </summary>
+    /// <remarks>
+    /// Called from the session's first render, after the app registered and
+    /// the wire version matched, and BEFORE the first tree is built. An
+    /// application that keeps nothing announces nothing and this returns
+    /// having touched no store.
+    /// </remarks>
+    internal static void Start()
+    {
+        Forget();
+
+        (string storage, List<SwiftPersistentKey> keys) = Announced();
+
+        if (keys.Count == 0)
+        {
+            return;
+        }
+
+        if (StateUIStores.Find(storage) is not { } store)
+        {
+            Complain(
+                $"the application keeps its state in a store called '{storage}', which " +
+                "nothing registered. Call StateUIStores.Add in MauiProgram.CreateMauiApp, " +
+                "before the first render. The kept state stays at its declared values.");
+            return;
+        }
+
+        Adopt(store, keys);
+
+        byte[] bytes = SwiftWire.WritePersistent(Hydrate());
+
+        try
+        {
+            if (NativeMethods.SetPersistent(bytes, bytes.Length) <= 0)
+            {
+                Complain(
+                    "the library refused what the store held. Usually a native library " +
+                    "and a runtime built from different versions.");
+            }
+        }
+        catch (EntryPointNotFoundException)
+        {
+            // A native library from before kept state existed. It announced no
+            // keys either, so this is unreachable in practice - and answering
+            // it anyway costs nothing and keeps the pair of exports symmetric
+            // with the environment's.
+            Complain("the native library predates kept state. Rebuild the Swift side.");
+        }
+    }
+
+    /// <summary>
+    /// Writes one key's new value into the store - what the
+    /// <see cref="SwiftAct.PersistValue"/> act asks for.
+    /// </summary>
+    /// <remarks>
+    /// The KIND comes from the announcement rather than from the value, so a
+    /// whole number declared as one is written with the store's integer
+    /// overload and reads back as one on the next launch. A key that was never
+    /// announced cannot be typed and is refused rather than guessed at - which
+    /// is the one way an application can get this wrong, and it is said out
+    /// loud.
+    /// </remarks>
+    /// <param name="command">The act, argument 0 the key, argument 1 its value.</param>
+    internal static void Save(SwiftCommand command)
+    {
+        if (command.GetName(0) is not { } name)
+        {
+            return;
+        }
+
+        if (_store is null || !Kinds.TryGetValue(name, out SwiftPersistentKind kind))
+        {
+            Complain(
+                $"'{name}' is kept state that the application does not list in " +
+                "persistentKeys, so this side cannot tell what kind of value it is and " +
+                "nothing was saved. Add it to the list.");
+            return;
+        }
+
+        try
+        {
+            switch (kind)
+            {
+                case SwiftPersistentKind.Boolean when command.GetBool(1) is { } value:
+                    _store.Set(name, value, null);
+                    break;
+
+                case SwiftPersistentKind.Integer when command.GetDouble(1) is { } value:
+                    _store.Set(name, (long)value, null);
+                    break;
+
+                case SwiftPersistentKind.Number when command.GetDouble(1) is { } value:
+                    _store.Set(name, value, null);
+                    break;
+
+                case SwiftPersistentKind.Text when command.GetString(1) is { } value:
+                    _store.Set(name, value, null);
+                    break;
+            }
+        }
+        catch (Exception exception)
+        {
+            // A store that will not take a value - a Windows container over
+            // its size limit, a file that cannot be written. The interface
+            // goes on working with the value it already holds; only the next
+            // launch is poorer for it.
+            Complain($"the store refused to keep '{name}': {exception.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Takes the store and the keys the application declared - the half of
+    /// <see cref="Start"/> that needs no native library, which is what lets it
+    /// be tested against a store of one's own.
+    /// </summary>
+    /// <param name="store">Where the state is kept.</param>
+    /// <param name="keys">Every key, in the order they were declared.</param>
+    internal static void Adopt(IPreferences store, IReadOnlyList<SwiftPersistentKey> keys)
+    {
+        _store = store;
+        _keys = [.. keys];
+        Kinds.Clear();
+
+        foreach (SwiftPersistentKey key in keys)
+        {
+            Kinds[key.Name] = key.Kind;
+        }
+    }
+
+    /// <summary>
+    /// What the store holds for the declared keys - a name and a value per key
+    /// that was THERE, in the order the application declared them.
+    /// </summary>
+    internal static List<(string Name, SwiftWireValue Value)> Hydrate()
+    {
+        List<(string Name, SwiftWireValue Value)> found = [];
+
+        foreach (SwiftPersistentKey key in _keys)
+        {
+            if (Read(key) is { } value)
+            {
+                found.Add((key.Name, value));
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>Forgets the store and the keys - what a second session starts
+    /// from, and what a test resets between cases.</summary>
+    internal static void Forget()
+    {
+        _store = null;
+        _keys = [];
+        Kinds.Clear();
+        _said = false;
+    }
+
+    /// <summary>
+    /// What Swift announced: the store's name and every key, or nothing at all
+    /// for an application that keeps nothing.
+    /// </summary>
+    private static (string Storage, List<SwiftPersistentKey> Keys) Announced()
+    {
+        IntPtr raw;
+        int length;
+
+        try
+        {
+            raw = NativeMethods.PersistentKeys(out length);
+        }
+        catch (EntryPointNotFoundException)
+        {
+            // A native library built before kept state. Nothing is kept, which
+            // is what such a library described anyway.
+            return (string.Empty, []);
+        }
+
+        if (raw == IntPtr.Zero || length <= 0)
+        {
+            return (string.Empty, []);
+        }
+
+        try
+        {
+            unsafe
+            {
+                return SwiftWire.ReadPersistentKeys(new ReadOnlySpan<byte>((void*)raw, length));
+            }
+        }
+        catch (InvalidDataException exception)
+        {
+            Complain($"the persistent keys would not read: {exception.Message}");
+            return (string.Empty, []);
+        }
+        finally
+        {
+            NativeMethods.FreeBuffer(raw);
+        }
+    }
+
+    /// <summary>
+    /// One key's value as the store holds it, or null when the store has
+    /// nothing under that name - which is what leaves the Swift state holding
+    /// the value written beside it.
+    /// </summary>
+    private static SwiftWireValue? Read(SwiftPersistentKey key)
+    {
+        try
+        {
+            if (_store is not { } store || !store.ContainsKey(key.Name, null))
+            {
+                return null;
+            }
+
+            return key.Kind switch
+            {
+                SwiftPersistentKind.Boolean => SwiftWireValue.Of(store.Get(key.Name, false, null)),
+                SwiftPersistentKind.Integer => SwiftWireValue.Of(
+                    (double)store.Get(key.Name, 0L, null)),
+                SwiftPersistentKind.Number => SwiftWireValue.Of(store.Get(key.Name, 0d, null)),
+                SwiftPersistentKind.Text => SwiftWireValue.Of(
+                    store.Get(key.Name, string.Empty, null)),
+                _ => null,
+            };
+        }
+        catch (Exception exception)
+        {
+            // The entry is there under a different type - written by an older
+            // version of the application, or by other code sharing the store.
+            // Android's SharedPreferences throws rather than converting.
+            // Reported and treated as absent, which starts the setting over
+            // instead of taking the app down on launch.
+            Complain($"'{key.Name}' is in the store as something else: {exception.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>Says something once - a store's trouble is a standing
+    /// condition, and one line per render would bury everything else.</summary>
+    private static void Complain(string message)
+    {
+        if (_said)
+        {
+            return;
+        }
+
+        _said = true;
+        StateUISession.Report(message);
+    }
+}

--- a/src/StateUI.Runtime/Rendering/StateUISession.cs
+++ b/src/StateUI.Runtime/Rendering/StateUISession.cs
@@ -348,6 +348,15 @@ internal sealed class StateUISession
                     return;
                 }
 
+                // KEPT STATE, before anything is built: a `@State` under a
+                // PersistentKey has to hold the stored value the first time a
+                // view reads it, and a Swift read cannot wait for this side.
+                // Once per process rather than once per render - the block is
+                // behind _initialized, and Resync deliberately does not clear
+                // it, or a lost generation would reload the store over live
+                // state.
+                StateUIPersistence.Start();
+
                 // The standard environment: every provider's values, told
                 // BEFORE the first tree is built - which pages exist may
                 // depend on the idiom - and wired to the platform's change
@@ -1206,6 +1215,13 @@ internal sealed class StateUISession
                     result = [SwiftWireValue.Of((int)offset.TotalMinutes)];
                     break;
                 }
+
+                case SwiftAct.PersistValue:
+                    // Nothing is waiting on this one: the value is already in
+                    // Swift's own state, and the store is where it goes to
+                    // survive the process.
+                    StateUIPersistence.Save(command);
+                    break;
 
                 case SwiftAct.HandlerFailed:
                     // A Swift handler let something escape. Nothing is waiting

--- a/src/StateUI.Runtime/Rendering/StateUIStores.cs
+++ b/src/StateUI.Runtime/Rendering/StateUIStores.cs
@@ -1,0 +1,79 @@
+using Microsoft.Maui.Storage;
+
+namespace StateUI.Runtime.Rendering;
+
+/// <summary>
+/// The application's own places to keep state - a store registered under a
+/// name, which the Swift side then names as its <c>persistentStorage</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An application that says nothing keeps its state in
+/// <see cref="Preferences.Default"/>, the platform's own settings store, and
+/// needs none of this. Register one only when the state belongs somewhere else
+/// - a file the application versions itself, an encrypted store, a store shared
+/// with a service.
+/// </para>
+/// <code>
+/// // C#, MauiProgram.CreateMauiApp:
+/// StateUIStores.Add("Gallery.Json", new JsonPreferences(path));
+///
+/// // Swift, on the Application:
+/// var persistentStorage: PersistentStorage { PersistentStorage("Gallery.Json") }
+/// </code>
+/// <para>
+/// A store is an <see cref="IPreferences"/> - MAUI's own interface, the one
+/// <see cref="Preferences.Default"/> implements - so there is nothing of this
+/// library's to conform to and a store written against MAUI works here
+/// unchanged. Only four value types are ever asked of it, the four a kept key
+/// can hold: <c>bool</c>, <c>long</c>, <c>double</c> and <c>string</c>.
+/// </para>
+/// <para>
+/// Registration must happen before the first render, which is what
+/// <c>MauiProgram.CreateMauiApp</c> is: the store is read once, before the
+/// first view is built, and a name that resolves to nothing by then is
+/// reported and the kept state stays at its declared values.
+/// </para>
+/// </remarks>
+public static class StateUIStores
+{
+    /// <summary>The name the Swift side's <c>.preferences</c> carries - the
+    /// platform's own store, and the answer to an application that names
+    /// none.</summary>
+    internal const string PreferencesName = "preferences";
+
+    private static readonly Lock Guard = new();
+    private static readonly Dictionary<string, IPreferences> Stores = [];
+
+    /// <summary>
+    /// Registers a store under a name. Registering the same name again
+    /// replaces the store.
+    /// </summary>
+    /// <param name="name">The name Swift's <c>PersistentStorage</c> carries.</param>
+    /// <param name="store">Where to keep the state.</param>
+    public static void Add(string name, IPreferences store)
+    {
+        lock (Guard)
+        {
+            Stores[name] = store;
+        }
+    }
+
+    /// <summary>
+    /// The store a name means: the platform's own for <c>"preferences"</c>,
+    /// otherwise whatever was registered - and null for a name nobody
+    /// registered.
+    /// </summary>
+    internal static IPreferences? Find(string name)
+    {
+        if (name == PreferencesName)
+        {
+            return Preferences.Default;
+        }
+
+        lock (Guard)
+        {
+            return Stores.GetValueOrDefault(name);
+        }
+    }
+}

--- a/src/StateUI.Runtime/Rendering/SwiftPages.cs
+++ b/src/StateUI.Runtime/Rendering/SwiftPages.cs
@@ -1435,6 +1435,7 @@ internal sealed class SwiftPages
                 case SwiftNodeType.NavigationPageTitleView:
                     NavigationPage.SetTitleView(
                         page, RenderSlot(NavigationPage.GetTitleView(page), child));
+                    WatchTitleViewWidth(page);
                     break;
 
                 case SwiftNodeType.ToolbarItems:
@@ -1498,6 +1499,64 @@ internal sealed class SwiftPages
     /// <param name="existing">The view that was in the slot.</param>
     /// <param name="wrapper">The node standing for the slot itself.</param>
     /// <returns>The view to put there, or what was there when nothing arrived.</returns>
+    /// <summary>
+    /// Pages whose title view is already watched for a bar that changed width.
+    /// </summary>
+    /// <remarks>
+    /// Weak, for the reason every other table here is: there is no one place a
+    /// page is dropped.
+    /// </remarks>
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Page, object> _titleViewWatched = new();
+
+    /// <summary>
+    /// Keeps a title view the width of the bar it is in, across a rotation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A title view's container is measured when it is set and keeps that
+    /// width, so a bar that grows leaves it CENTERED at the old size: measured
+    /// on an iPad mini in landscape, a container 667.5 points wide - the width
+    /// of the portrait bar it was built in - sitting 232.5 points from each
+    /// end, with the title's own text left-aligned inside it and so a third of
+    /// the way across the bar. Only the page on screen while the device turns
+    /// is affected; a page pushed afterwards is built at the new size.
+    /// </para>
+    /// <para>
+    /// The page's own SizeChanged is the moment the bar has the new width, and
+    /// SETTING THE TITLE VIEW AGAIN is what builds a container at that width -
+    /// laying the bar out again is not enough, measured: the container answers
+    /// with the size it was built with however often it is asked. The view
+    /// itself is the same instance, so nothing is rebuilt on this side.
+    /// Subscribed ONCE per page - a patch about a title view arrives on every
+    /// render that touches it - and on iOS ALONE: a Mac Catalyst window taken
+    /// from 700 to 1300 points keeps its title where it belongs (measured), and
+    /// a resize there is a live drag, so acting on every report would rebuild
+    /// the container tens of times for nothing.
+    /// </para>
+    /// </remarks>
+    private static void WatchTitleViewWidth(Page page)
+    {
+#if IOS
+        if (_titleViewWatched.TryGetValue(page, out _))
+        {
+            return;
+        }
+
+        _titleViewWatched.Add(page, new object());
+
+        page.SizeChanged += (_, _) =>
+        {
+            if (NavigationPage.GetTitleView(page) is View titleView)
+            {
+                NavigationPage.SetTitleView(page, null);
+                NavigationPage.SetTitleView(page, titleView);
+            }
+        };
+#else
+        _ = page;
+#endif
+    }
+
     internal View? RenderSlot(View? existing, SwiftNode wrapper)
     {
         return wrapper.Children is { Count: > 0 } children

--- a/src/StateUI.Runtime/Rendering/SwiftPages.cs
+++ b/src/StateUI.Runtime/Rendering/SwiftPages.cs
@@ -1494,12 +1494,6 @@ internal sealed class SwiftPages
     }
 
     /// <summary>
-    /// The one view inside a wrapper node - a header, a footer, a title view.
-    /// </summary>
-    /// <param name="existing">The view that was in the slot.</param>
-    /// <param name="wrapper">The node standing for the slot itself.</param>
-    /// <returns>The view to put there, or what was there when nothing arrived.</returns>
-    /// <summary>
     /// Pages whose title view is already watched for a bar that changed width.
     /// </summary>
     /// <remarks>
@@ -1557,6 +1551,12 @@ internal sealed class SwiftPages
 #endif
     }
 
+    /// <summary>
+    /// The one view inside a wrapper node - a header, a footer, a title view.
+    /// </summary>
+    /// <param name="existing">The view that was in the slot.</param>
+    /// <param name="wrapper">The node standing for the slot itself.</param>
+    /// <returns>The view to put there, or what was there when nothing arrived.</returns>
     internal View? RenderSlot(View? existing, SwiftNode wrapper)
     {
         return wrapper.Children is { Count: > 0 } children

--- a/src/StateUI.Runtime/StateUI.Runtime.csproj
+++ b/src/StateUI.Runtime/StateUI.Runtime.csproj
@@ -58,7 +58,7 @@
          assembly and the namespaces stay StateUI.Runtime; only what NuGet
          publishes is shortened. -->
     <PackageId>StateUI</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>Paweł Krzywdziński and Contributors</Authors>
     <Copyright>Copyright 2026 Paweł Krzywdziński and Contributors</Copyright>
     <Title>StateUI</Title>

--- a/src/StateUI.Template/README.md
+++ b/src/StateUI.Template/README.md
@@ -15,6 +15,10 @@ Name the app with letters and digits only: the name becomes the Swift module
 and the Android application id, and a hyphen or space in either fails far from
 its cause.
 
+The FIRST build takes ten minutes or more and is not a hang: it compiles
+swift-syntax from source, for the macro plugin behind `@StateClass`. Nothing of
+it ships in the app, and it is paid once - every build after it is seconds.
+
 # License
 
 Apache License 2.0, Copyright 2026 Paweł Krzywdziński and Contributors

--- a/src/StateUI.Template/StateUI.Template.csproj
+++ b/src/StateUI.Template/StateUI.Template.csproj
@@ -22,7 +22,7 @@
     <TargetFramework>net10.0</TargetFramework>
 
     <PackageId>StateUI.Template</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>Paweł Krzywdziński and Contributors</Authors>
     <Copyright>Copyright 2026 Paweł Krzywdziński and Contributors</Copyright>
     <Title>StateUI App Template</Title>

--- a/src/StateUI.Template/templates/StateUIStarter/.vscode/launch.json
+++ b/src/StateUI.Template/templates/StateUIStarter/.vscode/launch.json
@@ -8,6 +8,11 @@
   //   Windows, C# + Swift at once    -> Visual Studio, not VS Code
   //   Device or Android, Swift       -> not supported
   //
+  // THE PICKER LISTS THEM IN THAT ORDER, widest first: "Debug app (C#)" runs on
+  // every platform and every device, so it is what F5 offers before anything is
+  // chosen, and the Mac Catalyst compound is the narrowest. What decides that is
+  // `presentation.order` on each entry, NOT the order they appear in this file.
+  //
   // Swift debugging needs the process to be reachable by LLDB ON THIS MACHINE.
   // Mac Catalyst, the iOS Simulator and Windows all qualify - each runs the app
   // as an ordinary local process. A physical device or an Android emulator does
@@ -36,7 +41,7 @@
       "name": "Debug app (C#)",
       "type": "maui",
       "request": "launch",
-      "presentation": { "group": "1 app", "order": 2 }
+      "presentation": { "group": "1 app", "order": 1 }
     },
     {
       // The same launch against the RELEASE build. The pickers still apply
@@ -54,7 +59,7 @@
       "type": "maui",
       "request": "launch",
       "configuration": "Release",
-      "presentation": { "group": "1 app", "order": 3 }
+      "presentation": { "group": "1 app", "order": 2 }
     },
     {
       // Builds, launches WITHOUT a debugger, waits for the process, then
@@ -82,7 +87,7 @@
           "process attach --name StateUIStarter.exe"
         ]
       },
-      "presentation": { "group": "1 app", "order": 4 }
+      "presentation": { "group": "1 app", "order": 3 }
     },
     {
       // The Swift half of the compound below: attaches to an app the C# session
@@ -131,7 +136,7 @@
         "Attach Swift debugger"
       ],
       "stopAll": true,
-      "presentation": { "group": "1 app", "order": 1 }
+      "presentation": { "group": "1 app", "order": 4 }
     }
   ]
 }

--- a/src/StateUI.Template/templates/StateUIStarter/Package.swift
+++ b/src/StateUI.Template/templates/StateUIStarter/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         // and, in the .csproj beside this file:
         //
         //     <StateUIPackagePath>/path/to/StateUI/</StateUIPackagePath>
-        .package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.0"),
+        .package(url: "https://github.com/idexus/StateUI.git", exact: "0.1.1"),
     ],
     targets: [
         .target(

--- a/src/StateUI.Template/templates/StateUIStarter/StateUIStarter.csproj
+++ b/src/StateUI.Template/templates/StateUIStarter/StateUIStarter.csproj
@@ -96,7 +96,7 @@
          into real MAUI controls. The SWIFT half is a separate dependency, named
          by Package.swift beside this file - the two move together, so a
          version bump here wants the same version there. -->
-    <PackageReference Include="StateUI" Version="0.1.0" />
+    <PackageReference Include="StateUI" Version="0.1.1" />
   </ItemGroup>
 
   <!-- The app's own Swift UI lives in Swift/ next to this file. It is compiled

--- a/src/StateUI/Sources/Bridge/Exports.swift
+++ b/src/StateUI/Sources/Bridge/Exports.swift
@@ -331,6 +331,51 @@ public func stateui_set_environment(
     return StandardEnvironment.apply(domain: push.domain, values: push.payload) ? 1 : 0
 }
 
+/// Announces which store the application keeps state in and every key it keeps
+/// there, so the host can read exactly those. Writes the byte count into
+/// `length`.
+///
+/// Called ONCE, after the app registers and before the first render - the only
+/// moment where the application exists and no view has been built yet, which is
+/// what the hydration below has to happen inside. An application that keeps
+/// nothing answers a null pointer and a count of 0.
+///
+/// The caller owns the returned memory and must release it with
+/// stateui_free_buffer.
+@_cdecl("stateui_persistent_keys")
+public func stateui_persistent_keys(
+    _ length: UnsafeMutablePointer<Int32>?
+) -> UnsafeMutablePointer<UInt8>? {
+    makeBuffer(Renderer.shared.persistentWire(), length)
+}
+
+/// Takes what the host read out of the store: a name and a value for each key
+/// it FOUND, in the layout at `Wire.decodePersistent`.
+///
+/// Called once, before the first render, so a `@State` declared with one of
+/// these keys already holds the kept value the first time anything reads it.
+/// A key the store had nothing under is absent from the buffer, and the state
+/// keeps the value written beside it.
+///
+/// Returns 1 applied, -1 for a buffer that would not read - which the host
+/// reports once as version skew. The buffer is the caller's and is read before
+/// this returns.
+@_cdecl("stateui_set_persistent")
+public func stateui_set_persistent(
+    _ bytes: UnsafePointer<UInt8>?,
+    _ length: Int32
+) -> Int32 {
+    let buffer: [UInt8] = bytes.map {
+        Array(UnsafeBufferPointer(start: $0, count: Int(length)))
+    } ?? []
+
+    guard let found = Wire.decodePersistent(buffer) else { return -1 }
+
+    PersistentStore.shared.hydrate(found)
+
+    return 1
+}
+
 /// Releases a string any export here returned - stateui_platform is the
 /// only one that allocates this way.
 @_cdecl("stateui_free_string")

--- a/src/StateUI/Sources/Core/Persistence.swift
+++ b/src/StateUI/Sources/Core/Persistence.swift
@@ -1,0 +1,331 @@
+// State that outlives the process.
+//
+// `@State(.key) var group = 0` is an ordinary piece of state with one addition:
+// it is KEPT. The value the reader left behind is there on the next launch, and
+// nothing about reading or writing it changes - no load to await, no save to
+// remember.
+//
+// WHY THE KEYS ARE DECLARED UP FRONT. Reading a `@State` is synchronous, so the
+// value has to be in memory before the first view is built; asking the host at
+// read time would answer a render too late, and the reader would see the
+// default flash past. The host therefore hydrates the whole store BEFORE the
+// first render - and to read a store it has to know what to ask for, because
+// MAUI's `Preferences` can be read key by key and never enumerated. So the
+// application names its keys, in one list, and the three steps that follow all
+// happen inside the same startup window:
+//
+//   1. the host asks Swift for the keys      (stateui_persistent_keys)
+//   2. it reads exactly those from the store
+//   3. it pushes what it found back          (stateui_set_persistent)
+//
+// A key the store has no value for is simply absent from the push, and the
+// state keeps the value written beside it - which is what makes the default
+// live at the declaration, where it can be seen.
+//
+// WRITING is the other direction and needs nothing awaited: the value lands in
+// memory at once, so the read after the write is right, and the key is marked
+// for saving. What actually goes out is one act per key per drain, sorted by
+// name - see `Renderer.takeCommandsWire` - so an `Entry` bound to kept state
+// coalesces a burst of keystrokes into a single save instead of one per letter.
+//
+// ONE KEY IS ONE PIECE OF STATE, everywhere in the application. Two views that
+// declare the same key share the storage itself, not a copy of the value, so a
+// write in one rebuilds the readers in the other - the ordinary invalidation,
+// which already keys on storage identity. It is the one place in this library
+// where two unrelated views share state without `$` being written, and it is
+// what a key IS: a name for a value the whole application means.
+
+// Dispatch and not Foundation, for the lock below - the Renderer's reason: it
+// exists on every platform this targets, and Foundation on Windows links ICU.
+import Dispatch
+
+/// What kind of value a persistent key holds.
+///
+/// The host needs this before any state exists, because a store is typed: MAUI
+/// reads a `Preferences` entry with the overload matching what was written, and
+/// asking for the wrong one is an error rather than a conversion. It comes from
+/// the Swift type named at the key's declaration - `of: Int.self` - so there is
+/// no second vocabulary to keep in step.
+///
+/// THE NUMBERS ARE THIS LIBRARY'S OWN, the wire's rule: declaration order from
+/// 0, mirrored by `SwiftPersistentKind` on the far side and checked member for
+/// member by `WireEnumTests`.
+public enum PersistentKind: Int32, Sendable {
+    /// True or false. .NET: `bool`.
+    case boolean = 0
+
+    /// A whole number. .NET: `long` - and exact to 2^53, every number on this
+    /// wire being a Double.
+    case integer = 1
+
+    /// A number with a fraction. .NET: `double`.
+    case number = 2
+
+    /// Text. .NET: `string`.
+    case text = 3
+}
+
+/// A value a `@State` can be KEPT as.
+///
+/// Conformed to by `Bool`, `Int`, `Double` and `String` - what a platform's own
+/// settings store holds, which is deliberately the whole list: kept state lives
+/// where the rest of the application's settings live, so it can only be what
+/// that store can hold.
+///
+/// An enum over one of those four is one line, the raw value carrying it:
+///
+///     enum Appearance: String, PersistentValue { case light, dark, system }
+///
+/// Anything larger belongs in a model the application saves itself. A struct
+/// squeezed through this as text would be a format nobody versioned.
+public protocol PersistentValue {
+    /// Which of the four this is - what the host reads the store with.
+    static var persistentKind: PersistentKind { get }
+
+    /// The value, as the wire carries it.
+    var persistentValue: PropValue { get }
+
+    /// The value back from the wire, or nil when the store held something
+    /// else - an entry written by an older version of the application under
+    /// the same name. The state then keeps its declared value.
+    /// - Parameter persisted: what the host read out of the store.
+    init?(persisted: PropValue)
+}
+
+extension Bool: PersistentValue {
+    /// True or false.
+    public static var persistentKind: PersistentKind { .boolean }
+
+    /// The value, as the wire carries it.
+    public var persistentValue: PropValue { .bool(self) }
+
+    /// The value back from the wire, or nil for anything that is not a
+    /// boolean.
+    /// - Parameter persisted: what the host read out of the store.
+    public init?(persisted: PropValue) {
+        guard case .bool(let value) = persisted else { return nil }
+
+        self = value
+    }
+}
+
+extension Int: PersistentValue {
+    /// A whole number.
+    public static var persistentKind: PersistentKind { .integer }
+
+    /// The value, as the wire carries it - a Double, as everything numeric
+    /// here does.
+    public var persistentValue: PropValue { .number(Double(self)) }
+
+    /// The value back from the wire, or nil for anything that is not a number.
+    /// - Parameter persisted: what the host read out of the store.
+    public init?(persisted: PropValue) {
+        guard case .number(let value) = persisted else { return nil }
+
+        self = Int(value)
+    }
+}
+
+extension Double: PersistentValue {
+    /// A number with a fraction.
+    public static var persistentKind: PersistentKind { .number }
+
+    /// The value, as the wire carries it.
+    public var persistentValue: PropValue { .number(self) }
+
+    /// The value back from the wire, or nil for anything that is not a number.
+    /// - Parameter persisted: what the host read out of the store.
+    public init?(persisted: PropValue) {
+        guard case .number(let value) = persisted else { return nil }
+
+        self = value
+    }
+}
+
+extension String: PersistentValue {
+    /// Text.
+    public static var persistentKind: PersistentKind { .text }
+
+    /// The value, as the wire carries it.
+    public var persistentValue: PropValue { .string(self) }
+
+    /// The value back from the wire, or nil for anything that is not text.
+    /// - Parameter persisted: what the host read out of the store.
+    public init?(persisted: PropValue) {
+        guard case .string(let value) = persisted else { return nil }
+
+        self = value
+    }
+}
+
+extension PersistentValue where Self: RawRepresentable, Self.RawValue: PersistentValue {
+    /// Whatever the raw value is - an enum is kept as the thing it is spelled
+    /// with.
+    public static var persistentKind: PersistentKind { RawValue.persistentKind }
+
+    /// The raw value, as the wire carries it.
+    public var persistentValue: PropValue { rawValue.persistentValue }
+
+    /// The case the stored raw value names, or nil when it names none - a case
+    /// removed since the value was written, which is the ordinary way an
+    /// application's vocabulary changes between releases.
+    /// - Parameter persisted: what the host read out of the store.
+    public init?(persisted: PropValue) {
+        guard let raw = RawValue(persisted: persisted) else { return nil }
+
+        self.init(rawValue: raw)
+    }
+}
+
+/// The name a piece of state is KEPT under, and what kind of value it is.
+///
+///     extension PersistentKey {
+///         static let lastGroup = PersistentKey("com.example.lastGroup", of: Int.self)
+///         static let appearance = PersistentKey("com.example.appearance", of: Appearance.self)
+///     }
+///
+/// Declared the way every vocabulary in this library is - static members on an
+/// extension - and used in two places: the application lists them in
+/// `persistentKeys`, and a view writes one on the state it keeps.
+///
+///     @State(.lastGroup) private var group = 0
+///
+/// **The name is the application's and belongs to the whole platform**, not to
+/// this library: it sits beside whatever else the app keeps in the platform's
+/// settings, so a reverse-DNS prefix is what stops it from meeting another
+/// application's `theme`.
+///
+/// The kind comes from the Swift type rather than a vocabulary of its own, so
+/// `of: Int.self` and `var group = 0` are the same word twice and a mismatch
+/// between them is caught the first time the view is built.
+public struct PersistentKey: Hashable, Sendable, CustomStringConvertible {
+    /// The name in the store - what the host reads and writes under.
+    public let name: String
+
+    /// What kind of value it holds, taken from the type it was declared with.
+    public let kind: PersistentKind
+
+    /// A key from its name and the type of the value it keeps.
+    ///
+    ///     static let lastGroup = PersistentKey("com.example.lastGroup", of: Int.self)
+    ///
+    /// - Parameters:
+    ///   - name: the name in the platform's store, the application's own.
+    ///   - type: the type of the state kept under it.
+    public init<Value: PersistentValue>(_ name: String, of type: Value.Type) {
+        self.name = name
+        self.kind = Value.persistentKind
+    }
+
+    /// The name, so an interpolated diagnostic prints it plainly.
+    public var description: String { name }
+}
+
+/// WHERE kept state is kept. MAUI: Preferences, for the one this library ships.
+///
+/// An application says nothing and gets `.preferences`, which is MAUI's own
+/// store on every platform - `NSUserDefaults`, `SharedPreferences`,
+/// `ApplicationDataContainer`. Naming any other store names one the host
+/// registered under that name with `StateUIStores.Add`, which is how an
+/// application keeps its state somewhere of its own without this side knowing
+/// what a file is:
+///
+///     var persistentStorage: PersistentStorage { PersistentStorage("Gallery.Json") }
+public struct PersistentStorage: Hashable, Sendable, CustomStringConvertible {
+    /// The store's name - what the host resolves it by.
+    public let name: String
+
+    /// A store by name - one the application registered on the host side.
+    /// - Parameter name: the name it was registered under.
+    public init(_ name: String) {
+        self.name = name
+    }
+
+    /// The platform's own settings store, and the answer an application that
+    /// says nothing gets. MAUI: Preferences.
+    public static let preferences = PersistentStorage("preferences")
+
+    /// The name, so an interpolated diagnostic prints it plainly.
+    public var description: String { name }
+}
+
+/// Where kept state lives on this side: what the host hydrated, which storage
+/// stands for each key, and which keys are waiting to be saved.
+///
+/// `@unchecked Sendable` over its own lock, the Renderer's arrangement: a write
+/// can come from a child task a handler started, exactly as a queued act can.
+final class PersistentStore: @unchecked Sendable {
+    /// The one store. There is a single host per process, and the keys name
+    /// values that whole process shares.
+    static let shared = PersistentStore()
+
+    private let guarded = DispatchQueue(label: "StateUI.PersistentStore")
+
+    /// What the host read out of the store before the first render, by key
+    /// name. Read once per key, as the first state declaring it is built.
+    private var hydrated: [String: PropValue] = [:]
+
+    /// The storage standing for each key - a `State.Storage`, held as the
+    /// opaque object this file is allowed to know about. The FIRST state
+    /// declaring a key puts its own here, and every later one takes it, which
+    /// is what makes one key one piece of state.
+    private var storages: [String: AnyObject] = [:]
+
+    /// The keys written since the last drain, with the value to save. A key
+    /// written five times is here once, holding the last value - which is what
+    /// keeps a slider or an entry from saving on every report.
+    private var waiting: [String: PropValue] = [:]
+
+    /// Takes what the host read out of the store. Called once, before the
+    /// first render, so a state built later finds its value already here.
+    /// - Parameter values: name and value, for the keys the store had.
+    func hydrate(_ values: [(name: String, value: PropValue)]) {
+        guarded.sync {
+            for pair in values {
+                hydrated[pair.name] = pair.value
+            }
+        }
+    }
+
+    /// What the host read for a key, if anything.
+    func hydrated(_ key: PersistentKey) -> PropValue? {
+        guarded.sync { hydrated[key.name] }
+    }
+
+    /// The storage already standing for a key, or nil when this is the first
+    /// state to declare it.
+    func storage(for key: PersistentKey) -> AnyObject? {
+        guarded.sync { storages[key.name] }
+    }
+
+    /// Makes a storage the one this key means, for every state that declares
+    /// it from here on.
+    func adopt(_ storage: AnyObject, for key: PersistentKey) {
+        guarded.sync { storages[key.name] = storage }
+    }
+
+    /// Marks a key as needing a save, replacing whatever value was waiting.
+    func record(_ key: PersistentKey, _ value: PropValue) {
+        guarded.sync { waiting[key.name] = value }
+    }
+
+    /// The keys waiting to be saved, SORTED BY NAME, and forgets them - the
+    /// determinism rule, so two runs of one session write the same bytes.
+    func takeWaiting() -> [(name: String, value: PropValue)] {
+        guarded.sync {
+            let taken = waiting.sorted { $0.key < $1.key }
+            waiting.removeAll(keepingCapacity: true)
+            return taken.map { (name: $0.key, value: $0.value) }
+        }
+    }
+
+    /// Forgets everything - for tests, which build many sessions in one
+    /// process and must not inherit the last one's keys.
+    func forgetAll() {
+        guarded.sync {
+            hydrated.removeAll()
+            storages.removeAll()
+            waiting.removeAll()
+        }
+    }
+}

--- a/src/StateUI/Sources/Core/Renderer.swift
+++ b/src/StateUI/Sources/Core/Renderer.swift
@@ -653,6 +653,19 @@ public final class Renderer: @unchecked Sendable {
     /// An empty queue answers an empty array, and the export hands the host a
     /// null pointer for it - the common case, every pump, allocating nothing.
     func takeCommandsWire() -> [UInt8] {
+        // The saves waiting for a store, made into acts HERE rather than at
+        // the write: a key written five times between two takes is one act
+        // holding the last value, which is what keeps an Entry bound to kept
+        // state from saving once per letter. Sorted by name inside the store,
+        // the determinism rule.
+        //
+        // Nothing has to wake the host for these. A persistent write is a
+        // state write first, so the render it asks for is already coming, and
+        // the acts are drained after every render.
+        let saves = PersistentStore.shared.takeWaiting().map {
+            Command(act: .persistValue, arguments: [.name($0.name), $0.value], completion: nil)
+        }
+
         let queued = guarded.sync {
             let queued = commands
             commands.removeAll(keepingCapacity: true)
@@ -660,7 +673,23 @@ public final class Renderer: @unchecked Sendable {
             return queued
         }
 
-        return queued.isEmpty ? [] : Wire.encode(queued, dictionary: wireDictionary)
+        let batch = queued + saves
+
+        return batch.isEmpty ? [] : Wire.encode(batch, dictionary: wireDictionary)
+    }
+
+    /// Which store the application keeps state in, and every key it keeps
+    /// there - what the host hydrates from before the first render.
+    ///
+    /// Empty for an application that keeps nothing, which is most of them: the
+    /// host then reads no store and crosses nothing back. See
+    /// Core/Persistence.swift.
+    func persistentWire() -> [UInt8] {
+        guard let application, !application.persistentKeys.isEmpty else { return [] }
+
+        return Wire.encodePersistent(
+            storage: application.persistentStorage,
+            keys: application.persistentKeys)
     }
 
     /// Fails every act of the last taken batch, because the host could not

--- a/src/StateUI/Sources/Core/State.swift
+++ b/src/StateUI/Sources/Core/State.swift
@@ -58,6 +58,15 @@ public final class State<Value>: @unchecked Sendable {
 
     private var storage: Storage
 
+    /// What to do with a new value BESIDES holding it - present only on state
+    /// declared with a `PersistentKey`, where it marks the key for saving.
+    ///
+    /// A closure rather than the key itself, because turning a value into what
+    /// the wire carries needs `Value: PersistentValue` and this class is
+    /// generic over every value. The constraint therefore lives at the
+    /// initializer that makes the closure, and the setter below just calls it.
+    private var save: ((Value) -> Void)?
+
     /// State holding `initialValue`. The way to declare it at file scope, where
     /// a property wrapper is not allowed: `let counter = State(0)`.
     public init(_ initialValue: Value) {
@@ -80,6 +89,7 @@ public final class State<Value>: @unchecked Sendable {
         }
         set {
             storage.value = newValue
+            save?(newValue)
             Renderer.shared.stateChanged(storage)
         }
     }
@@ -140,6 +150,54 @@ extension State: StateBox {
         guard let other = other as? State<Value>, other !== self else { return }
 
         storage = other.storage
+    }
+}
+
+extension State where Value: PersistentValue {
+    /// State the application KEEPS - the same state, under a name, still there
+    /// on the next launch.
+    ///
+    ///     @State(.lastGroup) private var group = 0
+    ///
+    /// The value written here is what the state holds when the store has
+    /// nothing under that name - the first launch, or a value the reader never
+    /// changed - so the default lives where it can be seen. Reading and
+    /// writing are exactly what they are on any other `@State`: nothing is
+    /// awaited, the value is in memory before the first view is built, and a
+    /// write reaches the store by itself. See Core/Persistence.swift for how,
+    /// and for why the application also lists its keys.
+    ///
+    /// **One key is one piece of state.** Two views declaring the same key
+    /// share the storage, so a write in either rebuilds the readers in both.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: what the state holds when the store has nothing.
+    ///   - key: the name it is kept under, and the kind of value it is.
+    public convenience init(wrappedValue: Value, _ key: PersistentKey) {
+        self.init(wrappedValue: wrappedValue)
+
+        // The one thing an author can get wrong here, said at once rather
+        // than by quietly never being saved: the key was declared with a
+        // different type from the state written beside it.
+        precondition(
+            Value.persistentKind == key.kind,
+            "'\(key.name)' was declared to keep a \(key.kind) and is written "
+                + "on a \(Value.self), which is a \(Value.persistentKind)")
+
+        if let shared = PersistentStore.shared.storage(for: key) as? Storage {
+            // Another view got here first: this key already means that
+            // storage, and this state is that same state.
+            storage = shared
+        } else {
+            if let held = PersistentStore.shared.hydrated(key),
+               let value = Value(persisted: held) {
+                storage.value = value
+            }
+
+            PersistentStore.shared.adopt(storage, for: key)
+        }
+
+        save = { PersistentStore.shared.record(key, $0.persistentValue) }
     }
 }
 

--- a/src/StateUI/Sources/Core/Tokens.swift
+++ b/src/StateUI/Sources/Core/Tokens.swift
@@ -590,6 +590,11 @@ public extension Act {
     /// TimeZoneInfo.GetUtcOffset.
     static let getUtcOffset = Act("getUtcOffset")
 
+    /// This library's own: a persistent key's new value, on its way to the
+    /// store. Which store that is belongs to the host - see
+    /// Core/Persistence.swift.
+    static let persistValue = Act("persistValue")
+
     /// This library's own: a handler's escaped error, reported to the host.
     static let handlerFailed = Act("handlerFailed")
 }

--- a/src/StateUI/Sources/Core/Wire.swift
+++ b/src/StateUI/Sources/Core/Wire.swift
@@ -6,9 +6,11 @@
 // byte buffer the host reads IN PLACE, with no UTF-16 round trip and nothing
 // materialized on the way.
 //
-// SIX channels share the one value encoding below. This side WRITES the tree
-// and the acts; it READS the four the host writes - the two laid out here, and
-// the two at `decodeHostEvent` and `decodeEnvironment`:
+// SEVEN channels share the one value encoding below. This side WRITES the tree
+// and the acts; it READS the five the host writes - the two laid out here, and
+// the three at `decodeHostEvent`, `decodeEnvironment` and `decodePersistent`.
+// An eighth carries no values at all: `encodePersistent` announces the
+// application's persistent keys, which are names and a kind byte.
 //
 //   reply    [version: U8][ok: U8][count: U8][values...]
 //            what an act came to - the values a `try await` resumes with, or
@@ -414,6 +416,60 @@ public enum Wire {
         }
 
         return (name, values)
+    }
+
+    /// Announces which store the application keeps its state in and every key
+    /// it keeps there, so the host can read exactly those before the first
+    /// render:
+    ///
+    ///   [version: U8][storage: string][count: U16]
+    ///   per key: [name: string][kind: U8]
+    ///
+    /// Names in full rather than dictionary numbers: this is the FIRST thing
+    /// either side says, before any message has announced anything, and the
+    /// names belong to the platform's store rather than to a session.
+    static func encodePersistent(storage: PersistentStorage, keys: [PersistentKey]) -> [UInt8] {
+        var out: [UInt8] = []
+        out.u8(version)
+        out.string(storage.name)
+        out.u16(UInt16(keys.count))
+
+        for key in keys {
+            out.string(key.name)
+
+            // One byte for a vocabulary of four, where the tree's values would
+            // spend five. Nothing here is repeated often enough to be worth a
+            // dictionary entry.
+            out.u8(UInt8(truncatingIfNeeded: key.kind.rawValue))
+        }
+
+        return out
+    }
+
+    /// Decodes what the host read out of the store - a name and a value per
+    /// key it FOUND. A key the store had nothing under is simply absent, which
+    /// is what leaves the state holding the value written beside it.
+    ///
+    ///   [version: U8][count: U16]
+    ///   per entry: [name: string][value]
+    ///
+    /// Nil for a buffer that would not read, which the caller answers with -1
+    /// so the host can say version skew rather than nothing.
+    static func decodePersistent(_ bytes: [UInt8]) -> [(name: String, value: PropValue)]? {
+        var reader = Reader(bytes)
+
+        guard reader.u8() == version, let count = reader.u16() else { return nil }
+
+        var found: [(name: String, value: PropValue)] = []
+        found.reserveCapacity(Int(count))
+
+        for _ in 0..<count {
+            guard let name = reader.string(), let value = value(&reader) else { return nil }
+
+            found.append((name: name, value: value))
+        }
+
+        return reader.atEnd ? found : nil
     }
 
     /// Decodes a standard-environment push - which provider, then the same

--- a/src/StateUI/Sources/Views/Application.swift
+++ b/src/StateUI/Sources/Views/Application.swift
@@ -151,12 +151,43 @@ public protocol Application {
     /// resolved on this side, into the controls it applies to. See
     /// Views/Style.swift.
     var styles: StyleSheet? { get }
+
+    /// Every piece of state the application KEEPS between launches.
+    ///
+    ///     var persistentKeys: [PersistentKey] { [.lastGroup, .appearance] }
+    ///
+    /// The host reads exactly these out of the store before the first view is
+    /// built, so a `@State(.lastGroup)` already holds what the reader left
+    /// behind the first time anything looks at it.
+    ///
+    /// **A key left off this list is never read.** State declared with it
+    /// still SAVES - the write knows its own key - so the value appears on the
+    /// launch after next and the symptom is a setting that lags one run
+    /// behind. The list is the one thing that cannot be worked out from the
+    /// views, because a store is read key by key and the views that would name
+    /// the keys do not exist yet. See Core/Persistence.swift.
+    var persistentKeys: [PersistentKey] { get }
+
+    /// WHERE that state is kept. MAUI: Preferences, by default.
+    ///
+    /// The platform's own settings store unless the application names one it
+    /// registered on the host side with `StateUIStores.Add` - which is what an
+    /// application writes when its settings belong in a file of its own rather
+    /// than beside the platform's.
+    var persistentStorage: PersistentStorage { get }
 }
 
 extension Application {
     /// No styles of its own, which is what an application says by not writing
     /// this.
     public var styles: StyleSheet? { nil }
+
+    /// Nothing kept between launches, which is what an application says by not
+    /// writing this.
+    public var persistentKeys: [PersistentKey] { [] }
+
+    /// The platform's own settings store.
+    public var persistentStorage: PersistentStorage { .preferences }
 
     /// One window, the one `createWindow()` makes.
     public var windows: [Window] { [createWindow()] }

--- a/src/Tests/StateUIRuntime.Tests/PersistenceTests.cs
+++ b/src/Tests/StateUIRuntime.Tests/PersistenceTests.cs
@@ -1,0 +1,327 @@
+using System.Text;
+using Microsoft.Maui.Storage;
+using StateUI.Runtime.Protocol;
+using StateUI.Runtime.Rendering;
+
+namespace StateUIRuntime.Tests;
+
+/// <summary>
+/// KEPT STATE's host half: what the store is asked for, what comes back, and
+/// what a save writes.
+/// </summary>
+/// <remarks>
+/// A store here is an ordinary <see cref="IPreferences"/> of this file's own,
+/// which is the whole reason the seam is MAUI's interface rather than one of
+/// this library's: the path a real settings store takes is the path a
+/// dictionary takes, and no platform has to be running for it.
+/// </remarks>
+public class PersistenceTests : IDisposable
+{
+    private readonly FakeStore _store = new();
+
+    public PersistenceTests()
+    {
+        StateUIPersistence.Forget();
+    }
+
+    /// <summary>The store and the keys are one per process, so a case that
+    /// inherited the last one's would be reading somebody else's state.</summary>
+    public void Dispose()
+    {
+        StateUIPersistence.Forget();
+        GC.SuppressFinalize(this);
+    }
+
+    // The four keys the cases below keep, one of each kind.
+    private static readonly SwiftPersistentKey Count =
+        new("test.count", SwiftPersistentKind.Integer);
+
+    private static readonly SwiftPersistentKey Name =
+        new("test.name", SwiftPersistentKind.Text);
+
+    private static readonly SwiftPersistentKey Loud =
+        new("test.loud", SwiftPersistentKind.Boolean);
+
+    private static readonly SwiftPersistentKey Level =
+        new("test.level", SwiftPersistentKind.Number);
+
+    // MARK: - What Swift announced
+
+    /// <summary>
+    /// The announcement says where the state is kept and every key with the
+    /// kind it was declared as - the only way this side can learn what to ask
+    /// a store for, a settings store offering no list of what it holds.
+    /// </summary>
+    [Fact]
+    public void TheAnnouncementCarriesTheStoreAndEveryKeyWithItsKind()
+    {
+        List<byte> bytes = [SwiftWire.Version];
+        Str(bytes, "preferences");
+        bytes.AddRange([2, 0]);
+        Str(bytes, "test.count");
+        bytes.Add((byte)SwiftPersistentKind.Integer);
+        Str(bytes, "test.name");
+        bytes.Add((byte)SwiftPersistentKind.Text);
+
+        (string storage, List<SwiftPersistentKey> keys) =
+            SwiftWire.ReadPersistentKeys([.. bytes]);
+
+        Assert.Equal("preferences", storage);
+        Assert.Equal([Count, Name], keys);
+    }
+
+    /// <summary>
+    /// A buffer from a half built for another format is refused with a
+    /// sentence rather than read as something else.
+    /// </summary>
+    [Fact]
+    public void AnAnnouncementFromAnotherWireVersionIsRefused()
+    {
+        byte[] bytes = [SwiftWire.Version + 1, 0, 0, 0, 0, 0, 0];
+
+        Assert.Throws<InvalidDataException>(() => SwiftWire.ReadPersistentKeys(bytes));
+    }
+
+    // MARK: - Reading the store
+
+    /// <summary>
+    /// Each key is read with the overload its declared kind names, so what the
+    /// application wrote as a whole number comes back as one.
+    /// </summary>
+    [Fact]
+    public void EveryKeyIsReadAsTheKindItWasDeclared()
+    {
+        _store.Set("test.count", 7L, null);
+        _store.Set("test.name", "Ada", null);
+        _store.Set("test.loud", true, null);
+        _store.Set("test.level", 0.25, null);
+
+        StateUIPersistence.Adopt(_store, [Count, Name, Loud, Level]);
+
+        Assert.Equal(
+            [
+                ("test.count", SwiftWireValue.Of(7d)),
+                ("test.name", SwiftWireValue.Of("Ada")),
+                ("test.loud", SwiftWireValue.Of(true)),
+                ("test.level", SwiftWireValue.Of(0.25)),
+            ],
+            StateUIPersistence.Hydrate());
+    }
+
+    /// <summary>
+    /// A key the store has nothing under is simply LEFT OUT, which is what
+    /// leaves the Swift state holding the value written beside it. No sentinel
+    /// stands in for absence, the wire's rule.
+    /// </summary>
+    [Fact]
+    public void AKeyTheStoreHasNothingUnderIsLeftOut()
+    {
+        _store.Set("test.name", "Ada", null);
+
+        StateUIPersistence.Adopt(_store, [Count, Name]);
+
+        Assert.Equal([("test.name", SwiftWireValue.Of("Ada"))], StateUIPersistence.Hydrate());
+    }
+
+    /// <summary>
+    /// An entry the store holds as something ELSE - written by an older
+    /// version of the application under the same name, or by other code
+    /// sharing the store - is treated as absent rather than taking the launch
+    /// down. Android's SharedPreferences throws rather than converting, which
+    /// is what this store does.
+    /// </summary>
+    [Fact]
+    public void AnEntryHeldAsAnotherTypeIsTreatedAsAbsent()
+    {
+        _store.Set("test.count", "seven", null);
+
+        StateUIPersistence.Adopt(_store, [Count]);
+
+        Assert.Empty(StateUIPersistence.Hydrate());
+    }
+
+    /// <summary>
+    /// What was found is written back as a name and a value per key, in the
+    /// order the application declared them.
+    /// </summary>
+    [Fact]
+    public void WhatWasFoundIsWrittenBackByName()
+    {
+        byte[] bytes = SwiftWire.WritePersistent(
+            [("test.count", SwiftWireValue.Of(4d)), ("test.loud", SwiftWireValue.Of(true))]);
+
+        List<byte> expected = [SwiftWire.Version, 2, 0];
+        Str(expected, "test.count");
+        expected.Add(SwiftWireValue.TagNumber);
+        expected.AddRange(BitConverter.GetBytes(4d));
+        Str(expected, "test.loud");
+        expected.Add(SwiftWireValue.TagTrue);
+
+        Assert.Equal(expected, bytes);
+    }
+
+    // MARK: - Writing the store
+
+    /// <summary>
+    /// A save writes with the overload the key's declared kind names, so a
+    /// whole number goes in as one and reads back as one on the next launch.
+    /// The kind cannot come from the VALUE: every number on this wire is a
+    /// double, and nothing in it says which were declared whole.
+    /// </summary>
+    [Fact]
+    public void ASaveWritesWithTheOverloadTheKeysKindNames()
+    {
+        StateUIPersistence.Adopt(_store, [Count, Name, Loud, Level]);
+
+        StateUIPersistence.Save(Saving("test.count", bytes =>
+        {
+            bytes.Add(SwiftWireValue.TagNumber);
+            bytes.AddRange(BitConverter.GetBytes(7d));
+        }));
+
+        StateUIPersistence.Save(Saving("test.name", bytes =>
+        {
+            bytes.Add(SwiftWireValue.TagString);
+            Str(bytes, "Grace");
+        }));
+
+        StateUIPersistence.Save(Saving("test.loud", bytes => bytes.Add(SwiftWireValue.TagTrue)));
+
+        StateUIPersistence.Save(Saving("test.level", bytes =>
+        {
+            bytes.Add(SwiftWireValue.TagNumber);
+            bytes.AddRange(BitConverter.GetBytes(0.75));
+        }));
+
+        Assert.Equal(7L, _store.Held("test.count"));
+        Assert.Equal("Grace", _store.Held("test.name"));
+        Assert.Equal(true, _store.Held("test.loud"));
+        Assert.Equal(0.75, _store.Held("test.level"));
+    }
+
+    /// <summary>
+    /// A key the application does not list in <c>persistentKeys</c> cannot be
+    /// typed and is refused rather than guessed at - the one way an
+    /// application can get this wrong, and the reason it is said out loud
+    /// instead of silently written as whatever the value looked like.
+    /// </summary>
+    [Fact]
+    public void AKeyTheApplicationDoesNotListIsRefused()
+    {
+        StateUIPersistence.Adopt(_store, [Count]);
+
+        StateUIPersistence.Save(Saving("test.name", bytes =>
+        {
+            bytes.Add(SwiftWireValue.TagString);
+            Str(bytes, "Grace");
+        }));
+
+        Assert.Null(_store.Held("test.name"));
+    }
+
+    /// <summary>
+    /// A store that will not take a value leaves the interface alone: the
+    /// state already holds it, and only the next launch is poorer for it.
+    /// </summary>
+    [Fact]
+    public void AStoreThatRefusesAValueDoesNotTakeTheAppDown()
+    {
+        var refusing = new FakeStore { Refuses = true };
+        StateUIPersistence.Adopt(refusing, [Name]);
+
+        StateUIPersistence.Save(Saving("test.name", bytes =>
+        {
+            bytes.Add(SwiftWireValue.TagString);
+            Str(bytes, "Grace");
+        }));
+
+        Assert.Null(refusing.Held("test.name"));
+    }
+
+    // MARK: - Where it is kept
+
+    /// <summary>
+    /// A store registered under a name is what that name resolves to, and a
+    /// name nobody registered resolves to nothing - which is reported rather
+    /// than quietly keeping state nowhere.
+    /// </summary>
+    [Fact]
+    public void AStoreIsFoundByTheNameItWasRegisteredUnder()
+    {
+        StateUIStores.Add("Test.Json", _store);
+
+        Assert.Same(_store, StateUIStores.Find("Test.Json"));
+        Assert.Null(StateUIStores.Find("Test.NeverRegistered"));
+    }
+
+    // MARK: - Support
+
+    /// <summary>One save act, built the way the wire delivers it - the key as
+    /// a NAME through the session's dictionary, which is what
+    /// <see cref="SwiftCommand.GetName"/> reads.</summary>
+    private static SwiftCommand Saving(string key, Action<List<byte>> value)
+    {
+        List<byte> bytes = [SwiftWire.Version];
+
+        bytes.AddRange([2, 0]);                 // two announcements:
+        bytes.AddRange([1, 0]);
+        Str(bytes, "persistValue");             // name #1, the act
+        bytes.AddRange([2, 0]);
+        Str(bytes, key);                        // name #2, the key
+
+        bytes.AddRange([1, 0]);                 // one command
+        bytes.AddRange([1, 0]);                 // name #1
+        bytes.AddRange([0, 0, 0, 0]);           // nobody is waiting
+        bytes.Add(2);                           // two arguments
+
+        bytes.Add(SwiftWireValue.TagName);
+        bytes.AddRange([2, 0]);                 // name #2
+        value(bytes);
+
+        return SwiftWire.ReadCommands([.. bytes], new SwiftWireDictionary()).Single();
+    }
+
+    private static void Str(List<byte> bytes, string text)
+    {
+        byte[] utf8 = Encoding.UTF8.GetBytes(text);
+        bytes.AddRange(BitConverter.GetBytes((uint)utf8.Length));
+        bytes.AddRange(utf8);
+    }
+
+    /// <summary>
+    /// A settings store that is a dictionary - MAUI's own interface, so this
+    /// is the same seam a real one plugs into.
+    /// </summary>
+    private sealed class FakeStore : IPreferences
+    {
+        private readonly Dictionary<string, object> _values = [];
+
+        /// <summary>Whether every write fails - a container over its size
+        /// limit, a file that cannot be written.</summary>
+        public bool Refuses { get; init; }
+
+        public object? Held(string key) => _values.GetValueOrDefault(key);
+
+        public bool ContainsKey(string key, string? sharedName = null) =>
+            _values.ContainsKey(key);
+
+        public void Remove(string key, string? sharedName = null) => _values.Remove(key);
+
+        public void Clear(string? sharedName = null) => _values.Clear();
+
+        /// <summary>Reads, and THROWS for an entry held as another type -
+        /// which is what Android's SharedPreferences does.</summary>
+        public T Get<T>(string key, T defaultValue, string? sharedName = null) =>
+            _values.TryGetValue(key, out object? held) ? (T)held : defaultValue;
+
+        public void Set<T>(string key, T value, string? sharedName = null)
+        {
+            if (Refuses)
+            {
+                throw new InvalidOperationException("this store is full");
+            }
+
+            _values[key] = value!;
+        }
+    }
+}

--- a/src/Tests/StateUITests/PersistenceTests.swift
+++ b/src/Tests/StateUITests/PersistenceTests.swift
@@ -1,0 +1,295 @@
+// State that outlives the process: what is hydrated, what is shared, what is saved.
+
+import XCTest
+@testable import StateUI
+
+/// An enum kept as the text it is spelled with - one line, which is the point.
+private enum Appearance: String, PersistentValue {
+    case light
+    case dark
+}
+
+extension PersistentKey {
+    fileprivate static let count = PersistentKey("test.count", of: Int.self)
+    fileprivate static let name = PersistentKey("test.name", of: String.self)
+    fileprivate static let loud = PersistentKey("test.loud", of: Bool.self)
+    fileprivate static let level = PersistentKey("test.level", of: Double.self)
+    fileprivate static let appearance = PersistentKey("test.appearance", of: Appearance.self)
+}
+
+/// Two different views declaring the SAME key - which is the case that has to
+/// come out as one piece of state rather than two.
+private struct Sidebar {
+    @State(.count) var count = 0
+}
+
+private struct Footer {
+    @State(.count) var count = 0
+}
+
+private struct Preferences {
+    @State(.name) var name = "unnamed"
+    @State(.loud) var loud = false
+    @State(.level) var level = 0.5
+    @State(.appearance) var appearance = Appearance.light
+}
+
+private struct KeepingWindow: Window {
+    var content: Page { KeepingPage() }
+}
+
+private struct KeepingPage: ContentPage {
+    var content: Element { Label("kept") }
+}
+
+/// An application that keeps two of its settings, in the platform's own store.
+private struct KeepingApp: Application {
+    var persistentKeys: [PersistentKey] { [.count, .name] }
+
+    func createWindow() -> Window { KeepingWindow() }
+}
+
+/// An application that keeps its settings somewhere of its own.
+private struct FiledApp: Application {
+    var persistentStorage: PersistentStorage { PersistentStorage("Test.Json") }
+
+    var persistentKeys: [PersistentKey] { [.loud] }
+
+    func createWindow() -> Window { KeepingWindow() }
+}
+
+/// An application that keeps nothing, which is what most of them are.
+private struct PlainApp: Application {
+    func createWindow() -> Window { KeepingWindow() }
+}
+
+final class PersistenceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+
+        // The store is one per process and the keys name values that whole
+        // process shares, so a test that inherited the last one's would be
+        // reading somebody else's state.
+        PersistentStore.shared.forgetAll()
+        _ = drainedActs()
+    }
+
+    override func tearDown() {
+        PersistentStore.shared.forgetAll()
+        _ = drainedActs()
+        super.tearDown()
+    }
+
+    // MARK: - What a key is
+
+    /// A key's kind comes from the Swift type it was declared with, so
+    /// `of: Int.self` and `var count = 0` are the same word twice.
+    func testAKeyTakesItsKindFromTheTypeItWasDeclaredWith() {
+        XCTAssertEqual(PersistentKey.count.kind, .integer)
+        XCTAssertEqual(PersistentKey.name.kind, .text)
+        XCTAssertEqual(PersistentKey.loud.kind, .boolean)
+        XCTAssertEqual(PersistentKey.level.kind, .number)
+    }
+
+    /// An enum is kept as the thing it is spelled with, which is what makes
+    /// conformance one line and keeps the store readable by anything else that
+    /// opens it.
+    func testAnEnumIsKeptAsItsRawValue() {
+        XCTAssertEqual(PersistentKey.appearance.kind, .text)
+        XCTAssertEqual(Appearance.dark.persistentValue, .string("dark"))
+        XCTAssertEqual(Appearance(persisted: .string("light")), .light)
+
+        // A case removed since the value was written - the ordinary way an
+        // application's vocabulary changes between releases.
+        XCTAssertNil(Appearance(persisted: .string("sepia")))
+    }
+
+    // MARK: - Coming back
+
+    /// The value the host read out of the store is what the state holds the
+    /// first time anything looks at it - no load to await, nothing to put back.
+    func testAStateUnderAKeyTakesWhatTheHostHydrated() {
+        PersistentStore.shared.hydrate([
+            (name: "test.count", value: .number(7)),
+            (name: "test.name", value: .string("Ada")),
+        ])
+
+        XCTAssertEqual(Sidebar().count, 7)
+        XCTAssertEqual(Preferences().name, "Ada")
+    }
+
+    /// A key the store had nothing under leaves the state holding the value
+    /// written beside it - which is what puts the default where it can be seen.
+    func testAKeyTheStoreHadNothingUnderKeepsTheDeclaredValue() {
+        XCTAssertEqual(Sidebar().count, 0)
+        XCTAssertEqual(Preferences().name, "unnamed")
+        XCTAssertEqual(Preferences().appearance, .light)
+    }
+
+    /// An entry the store held as something else - written by an older version
+    /// of the application under the same name - is ignored rather than
+    /// force-fitted, and the state starts over at its declared value.
+    func testAValueTheStoreHeldAsSomethingElseIsIgnored() {
+        PersistentStore.shared.hydrate([(name: "test.count", value: .string("seven"))])
+
+        XCTAssertEqual(Sidebar().count, 0)
+    }
+
+    /// Two views declaring one key are ONE piece of state: they share the
+    /// storage itself, so a write in either is a write both read - and the
+    /// ordinary invalidation, which keys on storage identity, rebuilds both.
+    func testTwoStatesUnderOneKeyAreOnePieceOfState() {
+        let sidebar = Sidebar()
+        let footer = Footer()
+
+        sidebar.count = 12
+
+        XCTAssertEqual(footer.count, 12)
+        XCTAssertIdentical(sidebar.$count.lender, footer.$count.lender)
+    }
+
+    // MARK: - Going out
+
+    /// A write reaches the store by itself - one act, carrying the key as a
+    /// NAME and the value as the kind it was declared with.
+    func testWritingAKeptStateSendsItToTheStore() {
+        let preferences = Preferences()
+        preferences.name = "Grace"
+
+        let acts = drainedActs()
+
+        XCTAssertEqual(acts.count, 1)
+        XCTAssertEqual(acts.first?.name, "persistValue")
+        XCTAssertEqual(acts.first?.arguments, [.name("test.name"), .string("Grace")])
+
+        // Nothing is waiting on a save: the value is already in state, and the
+        // store is only where it goes to survive the process.
+        XCTAssertNil(acts.first?.completion)
+    }
+
+    /// A key written many times between two drains is saved ONCE, holding the
+    /// last value - which is what keeps an Entry bound to kept state from
+    /// saving on every letter.
+    func testAKeyWrittenManyTimesIsSavedOnceHoldingTheLastValue() {
+        let preferences = Preferences()
+
+        for text in ["G", "Gr", "Gra", "Grac", "Grace"] {
+            preferences.name = text
+        }
+
+        let acts = drainedActs()
+
+        XCTAssertEqual(acts.count, 1)
+        XCTAssertEqual(acts.first?.arguments, [.name("test.name"), .string("Grace")])
+    }
+
+    /// Saves ride the wire SORTED BY NAME, the determinism rule: one session
+    /// writes the same bytes in every run, and a dictionary iterated into a
+    /// message would not.
+    func testSavesRideTheWireSortedByName() {
+        let preferences = Preferences()
+        preferences.level = 0.25
+        preferences.name = "Ada"
+        preferences.loud = true
+
+        let names = drainedActs().compactMap { act -> String? in
+            guard case .name(let key)? = act.arguments.first else { return nil }
+            return key
+        }
+
+        XCTAssertEqual(names, ["test.level", "test.loud", "test.name"])
+    }
+
+    /// The saves come AFTER whatever the handlers queued, so an act a handler
+    /// awaited is not held up behind a store.
+    func testSavesComeAfterTheActsTheHandlersQueued() {
+        Renderer.shared.send(.hideSoftInput, [], completion: nil)
+        Sidebar().count = 3
+
+        XCTAssertEqual(drainedActs().map(\.name), ["hideSoftInput", "persistValue"])
+    }
+
+    /// Assigning the same value still saves. The state is unchanged and the
+    /// interface does not move, but the store may not hold it yet - a first
+    /// run where the reader put the value back where it started.
+    func testWritingTheValueItAlreadyHoldsStillReachesTheStore() {
+        Sidebar().count = 0
+
+        XCTAssertEqual(drainedActs().count, 1)
+    }
+
+    // MARK: - What the host is told
+
+    /// The announcement carries the store and every key, names in full: it is
+    /// the first thing either side says, before any message has announced a
+    /// dictionary to number them against.
+    func testTheAnnouncementCarriesTheStoreAndEveryKey() {
+        Renderer.shared.setApplication(KeepingApp())
+
+        var expected: [UInt8] = []
+        expected.u8(Wire.version)
+        expected.string("preferences")
+        expected.u16(2)
+        expected.string("test.count")
+        expected.u8(UInt8(PersistentKind.integer.rawValue))
+        expected.string("test.name")
+        expected.u8(UInt8(PersistentKind.text.rawValue))
+
+        XCTAssertEqual(Renderer.shared.persistentWire(), expected)
+    }
+
+    /// An application that keeps its state somewhere of its own says so in the
+    /// same announcement - the host resolves the name against what it has
+    /// registered.
+    func testTheAnnouncementNamesAStoreOfTheApplicationsOwn() {
+        Renderer.shared.setApplication(FiledApp())
+
+        var expected: [UInt8] = []
+        expected.u8(Wire.version)
+        expected.string("Test.Json")
+        expected.u16(1)
+        expected.string("test.loud")
+        expected.u8(UInt8(PersistentKind.boolean.rawValue))
+
+        XCTAssertEqual(Renderer.shared.persistentWire(), expected)
+    }
+
+    /// An application that keeps nothing announces nothing, and the host then
+    /// reads no store at all.
+    func testAnApplicationThatKeepsNothingAnnouncesNothing() {
+        Renderer.shared.setApplication(PlainApp())
+
+        XCTAssertEqual(Renderer.shared.persistentWire(), [])
+    }
+
+    /// What the host read comes back through the same value encoding every
+    /// other channel uses, and a key it did NOT find is simply absent.
+    func testWhatTheHostFoundIsReadBackByName() {
+        var buffer: [UInt8] = []
+        buffer.u8(Wire.version)
+        buffer.u16(2)
+        buffer.string("test.count")
+        buffer.value(.number(4))
+        buffer.string("test.loud")
+        buffer.value(.bool(true))
+
+        let found = Wire.decodePersistent(buffer)
+
+        XCTAssertEqual(found?.count, 2)
+        XCTAssertEqual(found?.first?.name, "test.count")
+        XCTAssertEqual(found?.first?.value, .number(4))
+        XCTAssertEqual(found?.last?.value, .bool(true))
+    }
+
+    /// A truncated buffer is a refusal rather than a wrong value - the reader
+    /// bounds-checks every step, as every channel here does.
+    func testATruncatedHydrationIsRefused() {
+        var buffer: [UInt8] = []
+        buffer.u8(Wire.version)
+        buffer.u16(2)
+        buffer.string("test.count")
+        buffer.value(.number(4))
+
+        XCTAssertNil(Wire.decodePersistent(buffer))
+    }
+}

--- a/src/Tests/StateUITests/TemplateTests.swift
+++ b/src/Tests/StateUITests/TemplateTests.swift
@@ -378,10 +378,18 @@ final class TemplateTests: XCTestCase {
             "the copied .scripts is not ignored - it would be committed and go stale against the original.")
     }
 
-    /// The three versions that have to agree: the runtime package, the reference
-    /// to it in the template, and the template package itself. They are released
+    /// The FOUR versions that have to agree: the runtime package, the reference
+    /// to it in the template, the template package itself, and the GIT TAG the
+    /// template's Package.swift pins the Swift half to. They are released
     /// together, and a template naming a version that was never published fails
     /// at restore - in somebody else's project, with nothing pointing back here.
+    ///
+    /// The Swift pin is the one that can fail while everything here is right:
+    /// NuGet and the git tag are two different publishings of one release, so
+    /// the number that resolves on the C# side says nothing about whether
+    /// `git tag 0.1.1` was ever pushed. This checks only that the two numbers
+    /// MATCH - that the tag exists is the release's job, and the symptom if it
+    /// does not is SwiftPM refusing to resolve in a generated app.
     func testEveryVersionAgrees() throws {
         let runtime = try version(of: "src/StateUI.Runtime/StateUI.Runtime.csproj")
         let templatePackage = try version(of: "src/StateUI.Template/StateUI.Template.csproj")
@@ -389,12 +397,20 @@ final class TemplateTests: XCTestCase {
         let project = try text(at: "\(token).csproj")
         let referenced = values(of: "Include=\"StateUI\" Version=\"", in: project).first
 
+        let manifest = try text(at: "Package.swift")
+        let pinned = values(of: "exact: \"", in: manifest).first
+
         XCTAssertEqual(
             referenced, runtime,
             "the template references StateUI \(referenced ?? "nothing") while the package is \(runtime).")
         XCTAssertEqual(
             templatePackage, runtime,
             "StateUI.Template is \(templatePackage) while StateUI is \(runtime); they ship together.")
+        XCTAssertEqual(
+            pinned, runtime,
+            "the template's Package.swift pins the Swift half to \(pinned ?? "nothing") while "
+                + "the C# half is \(runtime) - a generated app would build two halves from "
+                + "different releases, or fail to resolve the tag at all.")
     }
 
     // MARK: - Helpers

--- a/src/Tests/StateUITests/VsCodeTests.swift
+++ b/src/Tests/StateUITests/VsCodeTests.swift
@@ -283,6 +283,66 @@ final class VsCodeTests: XCTestCase {
         }
     }
 
+    /// THE PICKER'S ORDER IS `presentation.order`, NOT THE ORDER IN THE FILE -
+    /// and the widest-reaching launch is first.
+    ///
+    /// "Debug app (C#)" is the one that runs on every platform and every
+    /// device, so it is what F5 offers before anything has been chosen. The
+    /// Mac Catalyst compound is the narrowest of them and used to hold that
+    /// place, because it is written last in the file and carried `order: 1` -
+    /// which is exactly the mistake this reads for: a configuration moved in
+    /// the file changes nothing, and a number changed by hand changes
+    /// everything, with the two looking equally deliberate.
+    ///
+    /// Two orders that COLLIDE are the same failure quieter: VS Code then
+    /// breaks the tie however it likes, and the first entry stops being
+    /// anybody's decision.
+    func testTheWidestLaunchIsFirstInThePicker() throws {
+        for layout in layouts {
+            let launch = try json(at: layout.directory.appendingPathComponent("launch.json"))
+
+            // A compound is sorted in AMONG the configurations, so both lists
+            // are read - which is the whole reason the compound could be first
+            // while nothing in the configurations said so.
+            let entries = (array(launch, "configurations") + array(launch, "compounds"))
+                .compactMap { entry -> (group: String, order: Int, name: String)? in
+                    guard let name = entry["name"] as? String,
+                          let presentation = entry["presentation"] as? [String: Any],
+                          let group = presentation["group"] as? String,
+                          let order = presentation["order"] as? Int else { return nil }
+
+                    return (group, order, name)
+                }
+
+            XCTAssertEqual(
+                entries.count,
+                array(launch, "configurations").count + array(launch, "compounds").count,
+                "something in \(layout.name) has no presentation group and order, so where "
+                    + "it lands in the picker is not this file's decision.")
+
+            var seen: Set<String> = []
+
+            for entry in entries {
+                XCTAssertTrue(
+                    seen.insert("\(entry.group)/\(entry.order)").inserted,
+                    "\"\(entry.name)\" in \(layout.name) shares group \(entry.group) order "
+                        + "\(entry.order) with another entry - VS Code breaks that tie itself.")
+            }
+
+            let first = entries
+                .filter { $0.group == "1 app" }
+                .min { $0.order < $1.order }?
+                .name
+
+            XCTAssertEqual(
+                first, "Debug app (C#)",
+                "the app group in \(layout.name) offers \"\(first ?? "nothing")\" first. "
+                    + "\"Debug app (C#)\" belongs there: it is the only one that works on "
+                    + "every platform and every device, and it is what F5 runs before "
+                    + "anything is chosen.")
+        }
+    }
+
     // MARK: - Helpers
 
     /// JSON with comments, which is what VS Code writes, reduced to the JSON


### PR DESCRIPTION
## What this changes

- **Kept state** — `@State(.key)` survives a relaunch. Keys listed in
  `persistentKeys`, read out of MAUI's `Preferences` before the first view is
  built (a settings store cannot be enumerated). Own store via
  `StateUIStores.Add` + `persistentStorage`. Measured on Mac Catalyst and Windows.
- **iPad title view** keeps its place across a rotation — the container keeps
  the width it was built at; set again to rebuild it, `#if IOS`.
- **"Debug app (C#)" leads the launch picker** — the order is
  `presentation.order`, not file order. Both layouts, with a test.
- **README** — kept state documented, the ten-minute cold build explained
  (swift-syntax for the `@StateClass` plugin)
- **Packages 0.1.1**, in the nine places that have to agree.

Wire format unchanged — still version 8, no fixture moved.

## Checks

- [x] `swift test` 561, `dotnet test` 408
- [x] Docs, comments, wire — all as the template asks
